### PR TITLE
v0.2.4 EUP 9.3

### DIFF
--- a/Common/common_cl_fct.lua
+++ b/Common/common_cl_fct.lua
@@ -121,6 +121,12 @@ function EndHelpNotify(text, duration)
 	EndTextCommandDisplayHelp(0, 0, 0, duration)
 end
 
+function DisplayNotification(string)
+	SetTextComponentFormat("STRING")
+	AddTextComponentString(string)
+  DisplayHelpTextFromStringLabel(0, 0, 1, -1)
+end
+
 -- returns the first hit ped between two points on the map
 -- usage: bool, Vector3, EntityId = GetPedInDirection(Vector3, Vector3)
 function GetPedInDirection(coordFrom, coordTo)

--- a/Common/global_fct.lua
+++ b/Common/global_fct.lua
@@ -25,7 +25,7 @@ function GetNthBinaryFlag(x, n) -- returns the value of the bit at position 2**n
 	end
 	PaddedString = Digits .. String
 	Bit = 32 - n
-	BitValue = string.sub(PaddedString, Bit, Bit)	
+	BitValue = string.sub(PaddedString, Bit, Bit)
 	return BitValue
 end
 
@@ -33,4 +33,10 @@ end
 -- usage: bool = IsInt(NUMBER)
 function IsInt(n)
 	return n == math.floor(n)
+end
+
+function VectorDistance(x1, y1, z1, x2, y2, z2)
+  local dist = math.sqrt((x2-x1)^2 + (y2-y1)^2 + (z2-z1)^2)
+
+  return dist
 end

--- a/Config/Armories/Files/BCSOArmoryEUP.lua
+++ b/Config/Armories/Files/BCSOArmoryEUP.lua
@@ -1,9 +1,9 @@
 BCSOArmory = {
   {
     name = "Pistol",
-    handle = "weapon_pistol",
+    handle = "weapon_combatpistol",
     table = "Weapon",
-    ammo = 120,
+    ammo = 48,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -20,10 +20,10 @@ BCSOArmory = {
     },
   },
   {
-    name = "Submachine gun",
-    handle = "weapon_smg",
+    name = "Carbine",
+    handle = "weapon_carbinerifle",
     table = "Weapon",
-    ammo = 300,
+    ammo = 120,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -33,9 +33,9 @@ BCSOArmory = {
       },
     },
     attachments = {
-      HasAttachments = false,
+      HasAttachments = true,
       Components = {
-        {}
+        {'COMPONENT_AT_AR_FLSH', 'Flashlight'}
       },
     },
   },
@@ -43,7 +43,7 @@ BCSOArmory = {
     name = "Shotgun",
     handle = "weapon_pumpshotgun",
     table = "Weapon",
-    ammo = 80,
+    ammo = 32,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -89,28 +89,14 @@ BCSOArmory = {
       ArmorValue = 100,
       CompVars = {
         Male = {
-          {9,7,1},
-          {9,27,0},
-          {9,27,1},
-          {9,15,2},
-          {9,27,5},
-          {9,9,0},
-          {9,9,2},
-          {9,9,3},
-          {9,9,1},
-          {9,16,0},
+          {9,5,3},
+          {9,20,1},
+          {9,20,4},
         },
         Female = {
-          {9,29,0},
-          {9,29,1},
-          {9,17,2},
-          {9,17,1},
-          {9,29,5},
-          {9,6,0},
-          {9,6,2},
-          {9,6,3},
-          {9,6,1},
-          {9,18,0},
+          {9,3,3},
+          {9,23,1},
+          {9,23,4},
         },
       },
     },
@@ -131,27 +117,12 @@ BCSOArmory = {
       ArmorValue = 85,
       CompVars = {
         Male = {
-          {9,12,1},
-          {9,11,2},
-          {9,25,9},
-          {9,25,7},
-          {9,11,1},
+          {9,7,1},
+          {9,18,1},
         },
         Female = {
-          {9,3,2},
-          {9,12,2},
-          {9,12,1},
-          {9,27,9},
-          {9,27,7},
-          {9,13,2},
-          {9,8,2},
-          {9,9,2},
-          {9,10,2},
-          {9,13,1},
-          {9,3,1},
-          {9,8,1},
-          {9,9,1},
-          {9,10,1},
+          {9,7,1},
+          {9,22,7},
         },
       },
     },
@@ -172,12 +143,12 @@ BCSOArmory = {
       ArmorValue = 70,
       CompVars = {
         Male = {
+          {9,4,1},
           {9,4,2},
-          {9,4,0},
         },
         Female = {
+          {9,4,1},
           {9,4,2},
-          {9,4,0},
         },
       },
     },

--- a/Config/Armories/Files/BCSOArmoryVanilla.lua
+++ b/Config/Armories/Files/BCSOArmoryVanilla.lua
@@ -1,9 +1,9 @@
 BCSOArmory = {
   {
     name = "Pistol",
-    handle = "weapon_pistol",
+    handle = "weapon_combatpistol",
     table = "Weapon",
-    ammo = 120,
+    ammo = 48,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -20,10 +20,10 @@ BCSOArmory = {
     },
   },
   {
-    name = "Submachine gun",
-    handle = "weapon_smg",
+    name = "Carbine",
+    handle = "weapon_carbinerifle",
     table = "Weapon",
-    ammo = 300,
+    ammo = 120,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -33,9 +33,9 @@ BCSOArmory = {
       },
     },
     attachments = {
-      HasAttachments = false,
+      HasAttachments = true,
       Components = {
-        {}
+        {'COMPONENT_AT_AR_FLSH', 'Flashlight'}
       },
     },
   },
@@ -43,7 +43,7 @@ BCSOArmory = {
     name = "Shotgun",
     handle = "weapon_pumpshotgun",
     table = "Weapon",
-    ammo = 80,
+    ammo = 32,
     armor = {
       IsArmor = false,
       ArmorValue = 0,

--- a/Config/Armories/Files/DPOSArmoryEUP.lua
+++ b/Config/Armories/Files/DPOSArmoryEUP.lua
@@ -1,0 +1,122 @@
+DPOSArmory = {
+  {
+    name = "Flashlight",
+    handle = "weapon_flashlight",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Wrench",
+    handle = "weapon_wrench",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Hammer",
+    handle = "weapon_hammer",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Flare",
+    handle = "weapon_flare",
+    table = "Equipment",
+    ammo = 10,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Jerry Can",
+    handle = "weapon_petrolcan",
+    table = "Weapon",
+    ammo = 1000,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Fire Extinguisher",
+    handle = "weapon_fireextinguisher",
+    table = "Weapon",
+    ammo = 700,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+}

--- a/Config/Armories/Files/DPOSArmoryVanilla.lua
+++ b/Config/Armories/Files/DPOSArmoryVanilla.lua
@@ -1,0 +1,122 @@
+DPOSArmory = {
+  {
+    name = "Flashlight",
+    handle = "weapon_flashlight",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Wrench",
+    handle = "weapon_wrench",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Hammer",
+    handle = "weapon_hammer",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Flare",
+    handle = "weapon_flare",
+    table = "Equipment",
+    ammo = 10,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Jerry Can",
+    handle = "weapon_petrolcan",
+    table = "Weapon",
+    ammo = 1000,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Fire Extinguisher",
+    handle = "weapon_fireextinguisher",
+    table = "Weapon",
+    ammo = 700,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+}

--- a/Config/Armories/Files/FireArmoryEUP.lua
+++ b/Config/Armories/Files/FireArmoryEUP.lua
@@ -1,0 +1,102 @@
+FIREArmory = {
+  {
+    name = "Flashlight",
+    handle = "weapon_flashlight",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Crowbar",
+    handle = "weapon_crowbar",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Hatchet",
+    handle = "weapon_hatchet",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Flare",
+    handle = "weapon_flare",
+    table = "Equipment",
+    ammo = 10,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Fire Extinguisher",
+    handle = "weapon_fireextinguisher",
+    table = "Weapon",
+    ammo = 700,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+}

--- a/Config/Armories/Files/FireArmoryVanilla.lua
+++ b/Config/Armories/Files/FireArmoryVanilla.lua
@@ -1,0 +1,102 @@
+FIREArmory = {
+  {
+    name = "Flashlight",
+    handle = "weapon_flashlight",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Crowbar",
+    handle = "weapon_crowbar",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Hatchet",
+    handle = "weapon_hatchet",
+    table = "Equipment",
+    ammo = 1,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Flare",
+    handle = "weapon_flare",
+    table = "Equipment",
+    ammo = 10,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+  {
+    name = "Fire Extinguisher",
+    handle = "weapon_fireextinguisher",
+    table = "Weapon",
+    ammo = 700,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
+}

--- a/Config/Armories/Files/GeneralArmoryEUP.lua
+++ b/Config/Armories/Files/GeneralArmoryEUP.lua
@@ -79,4 +79,24 @@ GENArmory = {
       },
     },
   },
+  {
+    name = "Fire Extinguisher",
+    handle = "weapon_fireextinguisher",
+    table = "Equipment",
+    ammo = 700,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
 }

--- a/Config/Armories/Files/GeneralArmoryVanilla.lua
+++ b/Config/Armories/Files/GeneralArmoryVanilla.lua
@@ -146,5 +146,24 @@ GENArmory = {
       },
     },
   },
-
+  {
+    name = "Fire Extinguisher",
+    handle = "weapon_fireextinguisher",
+    table = "Equipment",
+    ammo = 700,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = false,
+      Components = {
+        {}
+      },
+    },
+  },
 }

--- a/Config/Armories/Files/LSPDArmoryEUP.lua
+++ b/Config/Armories/Files/LSPDArmoryEUP.lua
@@ -1,7 +1,27 @@
 LSPDArmory = {
   {
     name = "Pistol",
-    handle = "weapon_pistol_mk2",
+    handle = "weapon_combatpistol",
+    table = "Weapon",
+    ammo = 48,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = true,
+      Components = {
+        {'COMPONENT_AT_PI_FLSH', 'Flashlight'}
+      },
+    },
+  },
+  {
+    name = "Carbine",
+    handle = "weapon_carbinerifle",
     table = "Weapon",
     ammo = 120,
     armor = {
@@ -15,27 +35,7 @@ LSPDArmory = {
     attachments = {
       HasAttachments = true,
       Components = {
-        {'COMPONENT_AT_PI_FLSH_02', 'Flashlight'}
-      },
-    },
-  },
-  {
-    name = "Submachine gun",
-    handle = "weapon_smg",
-    table = "Weapon",
-    ammo = 300,
-    armor = {
-      IsArmor = false,
-      ArmorValue = 0,
-      CompVars = {
-        Male = {},
-        Female = {},
-      },
-    },
-    attachments = {
-      HasAttachments = false,
-      Components = {
-        {}
+        {'COMPONENT_AT_AR_FLSH', 'Flashlight'}
       },
     },
   },
@@ -43,7 +43,7 @@ LSPDArmory = {
     name = "Shotgun",
     handle = "weapon_pumpshotgun",
     table = "Weapon",
-    ammo = 80,
+    ammo = 32,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -69,18 +69,12 @@ LSPDArmory = {
       ArmorValue = 100,
       CompVars = {
         Male = {
-          {9,7,0},
-          {9,15,0},
-          {9,27,5},
-          {9,9,2},
-          {9,9,3},
+          {9,5,2},
+          {9,20,0},
         },
         Female = {
-          {9,17,0},
-          {9,29,5},
-          {9,6,2},
-          {9,6,3},
-
+          {9,3,2},
+          {9,23,0},
         },
       },
     },
@@ -101,20 +95,10 @@ LSPDArmory = {
       ArmorValue = 85,
       CompVars = {
         Male = {
-          {9,12,3},
-          {9,11,4},
-          {9,25,9},
-          {9,11,1},
+          {9,7,0},
         },
         Female = {
-          {9,3,4},
-          {9,12,1},
-          {9,27,9},
-          {9,8,1},
-          {9,13,1},
-          {9,9,1},
-          {9,10,1},
-          {9,3,1},
+          {9,7,0},
         },
       },
     },
@@ -135,11 +119,9 @@ LSPDArmory = {
       ArmorValue = 70,
       CompVars = {
         Male = {
-          {9,4,4},
           {9,4,0},
         },
         Female = {
-          {9,4,4},
           {9,4,0},
         },
       },

--- a/Config/Armories/Files/LSPDArmoryVanilla.lua
+++ b/Config/Armories/Files/LSPDArmoryVanilla.lua
@@ -1,7 +1,27 @@
 LSPDArmory = {
   {
     name = "Pistol",
-    handle = "weapon_pistol_mk2",
+    handle = "weapon_combatpistol",
+    table = "Weapon",
+    ammo = 48,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = true,
+      Components = {
+        {'COMPONENT_AT_PI_FLSH', 'Flashlight'}
+      },
+    },
+  },
+  {
+    name = "Carbine",
+    handle = "weapon_carbinerifle",
     table = "Weapon",
     ammo = 120,
     armor = {
@@ -15,27 +35,7 @@ LSPDArmory = {
     attachments = {
       HasAttachments = true,
       Components = {
-        {'COMPONENT_AT_PI_FLSH_02', 'Flashlight'}
-      },
-    },
-  },
-  {
-    name = "Submachine gun",
-    handle = "weapon_smg",
-    table = "Weapon",
-    ammo = 300,
-    armor = {
-      IsArmor = false,
-      ArmorValue = 0,
-      CompVars = {
-        Male = {},
-        Female = {},
-      },
-    },
-    attachments = {
-      HasAttachments = false,
-      Components = {
-        {}
+        {'COMPONENT_AT_AR_FLSH', 'Flashlight'}
       },
     },
   },
@@ -43,7 +43,7 @@ LSPDArmory = {
     name = "Shotgun",
     handle = "weapon_pumpshotgun",
     table = "Weapon",
-    ammo = 80,
+    ammo = 32,
     armor = {
       IsArmor = false,
       ArmorValue = 0,

--- a/Config/Armories/Files/SAPRArmoryEUP.lua
+++ b/Config/Armories/Files/SAPRArmoryEUP.lua
@@ -3,7 +3,7 @@ SAPRArmory = {
     name = "Pistol",
     handle = "weapon_combatpistol",
     table = "Weapon",
-    ammo = 120,
+    ammo = 48,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -16,6 +16,28 @@ SAPRArmory = {
       HasAttachments = true,
       Components = {
         {'COMPONENT_AT_PI_FLSH', 'Flashlight'}
+      },
+    },
+  },
+  {
+    name = "Hunting Rifle",
+    handle = "weapon_marksmanrifle_mk2",
+    table = "Weapon",
+    ammo = 30,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = true,
+      Components = {
+        {'COMPONENT_AT_AR_FLSH', 'Flashlight'},
+		{'COMPONENT_AT_SIGHTS', 'Holographic Sight'},
+		{'COMPONENT_AT_AR_SUPP', 'Suppressor'},
       },
     },
   },
@@ -40,40 +62,6 @@ SAPRArmory = {
     },
   },
   {
-    name = "Large Vest",
-    handle = "",
-    table = "Equipment",
-    ammo = 0,
-    armor = {
-      IsArmor = true,
-      ArmorValue = 100,
-      CompVars = {
-        Male = {
-          {9,9,0},
-          {9,9,2},
-          {9,27,5},
-          {9,9,1},
-          {9,9,3},
-          {9,16,0},
-        },
-        Female = {
-          {9,6,0},
-          {9,6,2},
-          {9,29,5},
-          {9,6,1},
-          {9,18,0},
-          {9,6,3},
-        },
-      },
-    },
-    attachments = {
-      HasAttachments = false,
-      Components = {
-        {}
-      },
-    },
-  },
-  {
     name = "Medium Vest",
     handle = "",
     table = "Equipment",
@@ -83,23 +71,16 @@ SAPRArmory = {
       ArmorValue = 85,
       CompVars = {
         Male = {
-          {9,25,9},
-          {9,25,7},
-          {9,11,1},
+          {9,18,2},
+          {9,18,3},
+          {9,18,4},
+          {9,36,0},
         },
         Female = {
-          {9,12,2},
-          {9,12,1},
-          {9,27,9},
-          {9,27,7},
-          {9,13,2},
-          {9,8,2},
-          {9,9,2},
-          {9,10,2},
-          {9,13,1},
-          {9,8,1},
-          {9,9,1},
-          {9,10,1},
+          {9,22,2},
+          {9,22,3},
+          {9,22,4},
+          {9,49,0},
         },
       },
     },
@@ -120,10 +101,10 @@ SAPRArmory = {
       ArmorValue = 70,
       CompVars = {
         Male = {
-          {9,4,0},
+          {9,4,3},
         },
         Female = {
-          {9,4,0},
+          {9,4,3},
         },
       },
     },

--- a/Config/Armories/Files/SAPRArmoryVanilla.lua
+++ b/Config/Armories/Files/SAPRArmoryVanilla.lua
@@ -3,7 +3,7 @@ SAPRArmory = {
     name = "Pistol",
     handle = "weapon_combatpistol",
     table = "Weapon",
-    ammo = 120,
+    ammo = 48,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -16,6 +16,28 @@ SAPRArmory = {
       HasAttachments = true,
       Components = {
         {'COMPONENT_AT_PI_FLSH', 'Flashlight'}
+      },
+    },
+  },
+  {
+    name = "Hunting Rifle",
+    handle = "weapon_marksmanrifle_mk2",
+    table = "Weapon",
+    ammo = 30,
+    armor = {
+      IsArmor = false,
+      ArmorValue = 0,
+      CompVars = {
+        Male = {},
+        Female = {},
+      },
+    },
+    attachments = {
+      HasAttachments = true,
+      Components = {
+        {'COMPONENT_AT_AR_FLSH', 'Flashlight'},
+		{'COMPONENT_AT_SIGHTS', 'Holographic Sight'},
+		{'COMPONENT_AT_AR_SUPP', 'Suppressor'},
       },
     },
   },

--- a/Config/Armories/Files/SASPArmoryEUP.lua
+++ b/Config/Armories/Files/SASPArmoryEUP.lua
@@ -1,9 +1,9 @@
 SASPArmory = {
   {
     name = "Pistol",
-    handle = "weapon_pistol50",
+    handle = "weapon_combatpistol",
     table = "Weapon",
-    ammo = 90,
+    ammo = 48,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -20,10 +20,10 @@ SASPArmory = {
     },
   },
   {
-    name = "Submachine gun",
-    handle = "weapon_smg",
+    name = "Carbine",
+    handle = "weapon_carbinerifle",
     table = "Weapon",
-    ammo = 300,
+    ammo = 120,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -33,9 +33,9 @@ SASPArmory = {
       },
     },
     attachments = {
-      HasAttachments = false,
+      HasAttachments = true,
       Components = {
-        {}
+        {'COMPONENT_AT_AR_FLSH', 'Flashlight'}
       },
     },
   },
@@ -43,7 +43,7 @@ SASPArmory = {
     name = "Shotgun",
     handle = "weapon_pumpshotgun",
     table = "Weapon",
-    ammo = 80,
+    ammo = 32,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -69,18 +69,12 @@ SASPArmory = {
       ArmorValue = 100,
       CompVars = {
         Male = {
-          {9,27,5},
-          {9,9,4},
-          {9,9,1},
-          {9,9,2},
-          {9,9,3},
+          {9,5,1},
+          {9,20,3},
         },
         Female = {
-          {9,29,5},
-          {9,6,4},
-          {9,6,1},
-          {9,6,2},
-          {9,6,3},
+          {9,3,1},
+          {9,23,3},
         },
       },
     },
@@ -101,29 +95,10 @@ SASPArmory = {
       ArmorValue = 85,
       CompVars = {
         Male = {
-          {9,12,0},
-          {9,25,6},
-          {9,25,8},
-          {9,25,9},
-          {9,11,0},
-          {9,11,1},
+          {9,7,4},
         },
         Female = {
-          {9,12,0},
-          {9,12,1},
-          {9,27,8},
-          {9,27,6},
-          {9,27,9},
-          {9,13,0},
-          {9,10,0},
-          {9,9,0},
-          {9,8,0},
-          {9,3,0},
-          {9,13,1},
-          {9,10,1},
-          {9,9,1},
-          {9,8,1},
-          {9,3,1},
+          {9,7,4},
         },
       },
     },
@@ -144,10 +119,10 @@ SASPArmory = {
       ArmorValue = 70,
       CompVars = {
         Male = {
-          {9,4,0},
+          {9,4,4},
         },
         Female = {
-          {9,4,0},
+          {9,4,4},
         },
       },
     },

--- a/Config/Armories/Files/SASPArmoryVanilla.lua
+++ b/Config/Armories/Files/SASPArmoryVanilla.lua
@@ -1,9 +1,9 @@
 SASPArmory = {
   {
     name = "Pistol",
-    handle = "weapon_pistol50",
+    handle = "weapon_combatpistol",
     table = "Weapon",
-    ammo = 90,
+    ammo = 48,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -20,10 +20,10 @@ SASPArmory = {
     },
   },
   {
-    name = "Submachine gun",
-    handle = "weapon_smg",
+    name = "Carbine",
+    handle = "weapon_carbinerifle",
     table = "Weapon",
-    ammo = 300,
+    ammo = 120,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -33,9 +33,9 @@ SASPArmory = {
       },
     },
     attachments = {
-      HasAttachments = false,
+      HasAttachments = true,
       Components = {
-        {}
+        {'COMPONENT_AT_AR_FLSH', 'Flashlight'}
       },
     },
   },
@@ -43,7 +43,7 @@ SASPArmory = {
     name = "Shotgun",
     handle = "weapon_pumpshotgun",
     table = "Weapon",
-    ammo = 80,
+    ammo = 32,
     armor = {
       IsArmor = false,
       ArmorValue = 0,

--- a/Config/Armories/Files/SWATArmoryEUP.lua
+++ b/Config/Armories/Files/SWATArmoryEUP.lua
@@ -1,9 +1,9 @@
 SWATArmory = {
   {
     name = "Pistol",
-    handle = "weapon_heavypistol",
+    handle = "weapon_combatpistol",
     table = "Weapon",
-    ammo = 180,
+    ammo = 48,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -15,37 +15,16 @@ SWATArmory = {
     attachments = {
       HasAttachments = true,
       Components = {
-        {'COMPONENT_AT_PI_FLSH', 'Flashlight'}
-      },
-    },
-  },
-  {
-    name = "Submachine gun",
-    handle = "weapon_smg",
-    table = "Weapon",
-    ammo = 300,
-    armor = {
-      IsArmor = false,
-      ArmorValue = 0,
-      CompVars = {
-        Male = {},
-        Female = {},
-      },
-    },
-    attachments = {
-      HasAttachments = true,
-      Components = {
-        {'COMPONENT_AT_AR_FLSH', 'Flashlight'},
-        {'COMPONENT_AT_PI_SUPP', 'Suppressor'},
-        {'COMPONENT_AT_SCOPE_MACRO_02', 'Scope'},
+        {'COMPONENT_AT_PI_FLSH', 'Flashlight'},
+		{'COMPONENT_AT_PI_SUPP', 'Suppressor'},
       },
     },
   },
   {
     name = "Carbine",
-    handle = "weapon_carbinerifle",
+    handle = "weapon_carbinerifle_mk2",
     table = "Weapon",
-    ammo = 300,
+    ammo = 120,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -57,17 +36,20 @@ SWATArmory = {
     attachments = {
       HasAttachments = true,
       Components = {
-        {"COMPONENT_AT_AR_AFGRIP", 'Grip'},
+        {"COMPONENT_AT_AR_AFGRIP_02", 'Grip'},
         {"COMPONENT_AT_AR_FLSH", 'Flashlight'},
-        {"COMPONENT_AT_SCOPE_MEDIUM", 'Scope'},
+		{"COMPONENT_AT_SCOPE_MEDIUM_MK2", 'Large Scope'},
+        {"COMPONENT_AT_SCOPE_MACRO_MK2", 'Small Scope'},
+		{"COMPONENT_AT_SIGHTS", 'Sights'},
+		{'COMPONENT_AT_AR_SUPP', 'Suppressor'},
       },
     },
   },
   {
     name = "Special Carbine",
-    handle = "weapon_specialcarbine",
+    handle = "weapon_specialcarbine_mk2",
     table = "Weapon",
-    ammo = 300,
+    ammo = 120,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -79,17 +61,20 @@ SWATArmory = {
     attachments = {
       HasAttachments = true,
       Components = {
-        {"COMPONENT_AT_AR_AFGRIP", 'Grip'},
+        {"COMPONENT_AT_AR_AFGRIP_02", 'Grip'},
         {"COMPONENT_AT_AR_FLSH", 'Flashlight'},
-        {"COMPONENT_AT_SCOPE_MEDIUM", 'Scope'},
+		{"COMPONENT_AT_SCOPE_MEDIUM_MK2", 'Large Scope'},
+        {"COMPONENT_AT_SCOPE_MACRO_MK2", 'Small Scope'},
+		{"COMPONENT_AT_SIGHTS", 'Sights'},
+		{'COMPONENT_AT_AR_SUPP', 'Suppressor'},
       },
     },
   },
   {
     name = "Shotgun",
-    handle = "weapon_heavyshotgun",
+    handle = "weapon_pumpshotgun_mk2",
     table = "Weapon",
-    ammo = 300,
+    ammo = 32,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -103,7 +88,6 @@ SWATArmory = {
       Components = {
         {'COMPONENT_AT_AR_FLSH', 'Flashlight'},
         {'COMPONENT_AT_AR_AFGRIP', 'Grip'},
-        {'COMPONENT_HEAVYSHOTGUN_CLIP_03', 'Drum Magazine'}
       },
     },
   },
@@ -111,7 +95,7 @@ SWATArmory = {
     name = "Sniper Rifle",
     handle = "weapon_sniperrifle",
     table = "Weapon",
-    ammo = 100,
+    ammo = 30,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -131,7 +115,7 @@ SWATArmory = {
     name = "Tear gas",
     handle = "weapon_smokegrenade",
     table = "Equipment",
-    ammo = 5,
+    ammo = 25,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -157,14 +141,16 @@ SWATArmory = {
       ArmorValue = 100,
       CompVars = {
         Male = {
-          {9,9,2},
-          {9,27,5},
-          {9,9,3},
+          {9,16,0},
+          {9,27,0},
+          {9,27,2},
+          {9,27,6},
         },
         Female = {
-          {9,6,2},
-          {9,29,5},
-          {9,6,3},
+          {9,18,0},
+          {9,29,0},
+          {9,29,2},
+          {9,29,6},
         },
       },
     },
@@ -175,59 +161,5 @@ SWATArmory = {
       },
     },
   },
-  {
-    name = "Medium Vest",
-    handle = "",
-    table = "Equipment",
-    ammo = 0,
-    armor = {
-      IsArmor = true,
-      ArmorValue = 85,
-      CompVars = {
-        Male = {
-          {9,25,9},
-          {9,11,1},
-        },
-        Female = {
-          {9,12,1},
-          {9,27,9},
-          {9,13,1},
-          {9,8,1},
-          {9,9,1},
-          {9,10,1},
-          {9,3,1},
-        },
-      },
-    },
-    attachments = {
-      HasAttachments = false,
-      Components = {
-        {}
-      },
-    },
-  },
-  {
-    name = "Small Vest",
-    handle = "",
-    table = "Equipment",
-    ammo = 0,
-    armor = {
-      IsArmor = true,
-      ArmorValue = 70,
-      CompVars = {
-        Male = {
-          {9,4,0},
-        },
-        Female = {
-          {9,4,0},
-        },
-      },
-    },
-    attachments = {
-      HasAttachments = false,
-      Components = {
-        {}
-      },
-    },
-  },
+
 }

--- a/Config/Armories/Files/SWATArmoryVanilla.lua
+++ b/Config/Armories/Files/SWATArmoryVanilla.lua
@@ -1,9 +1,9 @@
 SWATArmory = {
   {
     name = "Pistol",
-    handle = "weapon_heavypistol",
+    handle = "weapon_combatpistol",
     table = "Weapon",
-    ammo = 180,
+    ammo = 48,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -15,37 +15,16 @@ SWATArmory = {
     attachments = {
       HasAttachments = true,
       Components = {
-        {'COMPONENT_AT_PI_FLSH', 'Flashlight'}
-      },
-    },
-  },
-  {
-    name = "Submachine gun",
-    handle = "weapon_smg",
-    table = "Weapon",
-    ammo = 300,
-    armor = {
-      IsArmor = false,
-      ArmorValue = 0,
-      CompVars = {
-        Male = {},
-        Female = {},
-      },
-    },
-    attachments = {
-      HasAttachments = true,
-      Components = {
-        {'COMPONENT_AT_AR_FLSH', 'Flashlight'},
-        {'COMPONENT_AT_PI_SUPP', 'Suppressor'},
-        {'COMPONENT_AT_SCOPE_MACRO_02', 'Scope'},
+        {'COMPONENT_AT_PI_FLSH', 'Flashlight'},
+		{'COMPONENT_AT_PI_SUPP', 'Suppressor'},
       },
     },
   },
   {
     name = "Carbine",
-    handle = "weapon_carbinerifle",
+    handle = "weapon_carbinerifle_mk2",
     table = "Weapon",
-    ammo = 300,
+    ammo = 120,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -57,17 +36,20 @@ SWATArmory = {
     attachments = {
       HasAttachments = true,
       Components = {
-        {"COMPONENT_AT_AR_AFGRIP", 'Grip'},
+        {"COMPONENT_AT_AR_AFGRIP_02", 'Grip'},
         {"COMPONENT_AT_AR_FLSH", 'Flashlight'},
-        {"COMPONENT_AT_SCOPE_MEDIUM", 'Scope'},
+		{"COMPONENT_AT_SCOPE_MEDIUM_MK2", 'Large Scope'},
+        {"COMPONENT_AT_SCOPE_MACRO_MK2", 'Small Scope'},
+		{"COMPONENT_AT_SIGHTS", 'Sights'},
+		{'COMPONENT_AT_AR_SUPP', 'Suppressor'},
       },
     },
   },
   {
     name = "Special Carbine",
-    handle = "weapon_specialcarbine",
+    handle = "weapon_specialcarbine_mk2",
     table = "Weapon",
-    ammo = 300,
+    ammo = 120,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -78,18 +60,21 @@ SWATArmory = {
     },
     attachments = {
       HasAttachments = true,
-      Components = {
-        {"COMPONENT_AT_AR_AFGRIP", 'Grip'},
+	  Components = {
+        {"COMPONENT_AT_AR_AFGRIP_02", 'Grip'},
         {"COMPONENT_AT_AR_FLSH", 'Flashlight'},
-        {"COMPONENT_AT_SCOPE_MEDIUM", 'Scope'},
+		{"COMPONENT_AT_SCOPE_MEDIUM_MK2", 'Large Scope'},
+        {"COMPONENT_AT_SCOPE_MACRO_MK2", 'Small Scope'},
+		{"COMPONENT_AT_SIGHTS", 'Sights'},
+		{'COMPONENT_AT_AR_SUPP', 'Suppressor'},
       },
     },
   },
   {
     name = "Shotgun",
-    handle = "weapon_heavyshotgun",
+    handle = "weapon_pumpshotgun_mk2",
     table = "Weapon",
-    ammo = 300,
+    ammo = 32,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -103,7 +88,6 @@ SWATArmory = {
       Components = {
         {'COMPONENT_AT_AR_FLSH', 'Flashlight'},
         {'COMPONENT_AT_AR_AFGRIP', 'Grip'},
-        {'COMPONENT_HEAVYSHOTGUN_CLIP_03', 'Drum Magazine'}
       },
     },
   },
@@ -111,7 +95,7 @@ SWATArmory = {
     name = "Sniper Rifle",
     handle = "weapon_sniperrifle",
     table = "Weapon",
-    ammo = 100,
+    ammo = 30,
     armor = {
       IsArmor = false,
       ArmorValue = 0,
@@ -131,7 +115,7 @@ SWATArmory = {
     name = "Tear gas",
     handle = "weapon_smokegrenade",
     table = "Equipment",
-    ammo = 5,
+    ammo = 25,
     armor = {
       IsArmor = false,
       ArmorValue = 0,

--- a/Config/Armories/armory_cl.lua
+++ b/Config/Armories/armory_cl.lua
@@ -5,6 +5,8 @@ ListBCSOArmory = {}
 ListSASPArmory = {}
 ListSAPRArmory = {}
 ListSWATArmory = {}
+ListFIREArmory = {}
+ListDPOSArmory = {}
 
 ArmoryUnderarmorVestDefinition = {
   name = "Underarmor Vest",
@@ -187,3 +189,61 @@ end
 
 table.insert(ListSWATArmory, ListSWATEquipment)
 table.insert(ListSWATArmory, ListSWATWeapons)
+
+-- FIRE Tables init
+local ListFIREEquipment = {
+  data = {},
+  names = {},
+  handles = {},
+  ammo = {},
+  IsArmor = {},
+  HasAttachments = {},
+}
+local ListFIREWeapons = {
+  data = {},
+  names = {},
+  handles = {},
+  ammo = {},
+  IsArmor = {},
+  HasAttachments = {},
+}
+
+for i, option in ipairs(FIREArmory) do
+  if option.table == 'Equipment' then
+    table.insert(ListFIREEquipment.data, option)
+  elseif option.table == 'Weapon' then
+    table.insert(ListFIREWeapons.data, option)
+  end
+end
+
+table.insert(ListFIREArmory, ListFIREEquipment)
+table.insert(ListFIREArmory, ListFIREWeapons)
+
+-- DPOS Tables init
+local ListDPOSEquipment = {
+  data = {},
+  names = {},
+  handles = {},
+  ammo = {},
+  IsArmor = {},
+  HasAttachments = {},
+}
+local ListDPOSWeapons = {
+  data = {},
+  names = {},
+  handles = {},
+  ammo = {},
+  IsArmor = {},
+  HasAttachments = {},
+}
+
+for i, option in ipairs(DPOSArmory) do
+  if option.table == 'Equipment' then
+    table.insert(ListDPOSEquipment.data, option)
+  elseif option.table == 'Weapon' then
+    table.insert(ListDPOSWeapons.data, option)
+  end
+end
+
+table.insert(ListDPOSArmory, ListDPOSEquipment)
+table.insert(ListDPOSArmory, ListDPOSWeapons)

--- a/Config/Stations/Med/CentralLSVanilla.lua
+++ b/Config/Stations/Med/CentralLSVanilla.lua
@@ -28,5 +28,11 @@ MedCentralLS = {
     help = {
 
     },
+    tp = {
+      {x=376.34, y=-1443.5, z=29.43, handle='CentralLSMed'},
+    },
+    weap = {
+      {x=298.93, y=-1451.34, z=29.97, handle='CentralLSMed'},
+    },
   },
 }

--- a/Config/Stations/Med/DavisFDVanilla.lua
+++ b/Config/Stations/Med/DavisFDVanilla.lua
@@ -26,5 +26,11 @@ FireDavis = {
     help = {
 
     },
+    tp = {
+      {x=198.89, y=-1647.02, z=29.8, handle='DavisFire'},
+    },
+    weap = {
+      {x=205.92, y=-1661.4, z=29.8, handle='DavisFire'},
+    },
   },
 }

--- a/Config/Stations/Med/EclipseVanilla.lua
+++ b/Config/Stations/Med/EclipseVanilla.lua
@@ -26,5 +26,11 @@ MedEclipse = {
     help = {
 
     },
+    tp = {
+      {x=-664.48, y=312.12, z=83.09, handle='EclipseMed'},
+    },
+    weap = {
+      {x=-687.74, y=314.19, z=83.09, handle='EclipseMed'},
+    },
   },
 }

--- a/Config/Stations/Med/FiacreVanilla.lua
+++ b/Config/Stations/Med/FiacreVanilla.lua
@@ -30,5 +30,11 @@ MedFiacre = {
     help = {
 
     },
+    tp = {
+      {x=1189.37, y=-1529.64, z=34.69, handle= 'FiacreMed'},
+    },
+    weap = {
+      {x=1207.8, y=-1495.45, z=34.84, handle='FiacreMed'},
+    },
   },
 }

--- a/Config/Stations/Med/MountZonahVanilla.lua
+++ b/Config/Stations/Med/MountZonahVanilla.lua
@@ -38,5 +38,11 @@ MedMountZonah = {
     help = {
 
     },
+    tp = {
+      {x=-418.36, y=-330.43, z=42.22, handle='MountZonahMed'},
+    },
+    weap = {
+      {x=-475.28, y=-279.99, z=35.68, handle='MountZonahMed'},
+    },
   },
 }

--- a/Config/Stations/Med/PaletoBayBrown.lua
+++ b/Config/Stations/Med/PaletoBayBrown.lua
@@ -27,5 +27,11 @@ MedPaleto = {
     help = {
 
     },
+    tp = {
+      {x=-257.06, y=6352.0, z=32.34, handle='PaletoMed'},
+    },
+    weap = {
+      {x=-259.58, y=6333.49, z=32.43, handle='PaletoMed'},
+    },
   },
 }

--- a/Config/Stations/Med/PaletoBayFDVanilla.lua
+++ b/Config/Stations/Med/PaletoBayFDVanilla.lua
@@ -26,5 +26,11 @@ FirePaleto = {
     help = {
 
     },
+    tp = {
+      {x=-379.91, y=6087.44, z=31.6, handle='PaletoFire'},
+    },
+    weap = {
+      {x=-371.08, y=6100.46, z=31.49, handle='PaletoFire'},
+    },
   },
 }

--- a/Config/Stations/Med/PaletoBayVanilla.lua
+++ b/Config/Stations/Med/PaletoBayVanilla.lua
@@ -26,5 +26,11 @@ MedPaleto = {
     help = {
 
     },
+    tp = {
+      {x=-257.06, y=6352.0, z=32.34, handle='PaletoMed'},
+    },
+    weap = {
+      {x=-259.58, y=6333.49, z=32.43, handle='PaletoMed'},
+    },
   },
 }

--- a/Config/Stations/Med/PillboxHillVanilla.lua
+++ b/Config/Stations/Med/PillboxHillVanilla.lua
@@ -28,5 +28,11 @@ MedPillbox = {
     help = {
 
     },
+    tp = {
+      {x=312.27, y=-553.48, z=28.88, handle = 'PillboxMed'},
+    },
+    weap = {
+      {x=314.76, y=-540.22, z=28.74, handle='PillboxMed'},
+    },
   },
 }

--- a/Config/Stations/Med/PortolaVanilla.lua
+++ b/Config/Stations/Med/PortolaVanilla.lua
@@ -26,5 +26,11 @@ MedPortola = {
     help = {
 
     },
+    tp = {
+      {x=-884.44, y=-331.03, z=38.98, handle='PortolaMed'},
+    },
+    weap = {
+      {x=-921.07, y=-323.65, z=39.19, handle='PortolaMed'},
+    },
   },
 }

--- a/Config/Stations/Med/RockfordHillsFDVanilla.lua
+++ b/Config/Stations/Med/RockfordHillsFDVanilla.lua
@@ -26,5 +26,11 @@ FireRockford = {
     help = {
 
     },
+    tp = {
+      {x=-635.43, y=-127.13, z=39.01, handle='RockfordFire'},
+    },
+    weap = {
+      {x=-636.0, y=-116.79, z=38.03, handle='RockfordFire'},
+    },
   },
 }

--- a/Config/Stations/Med/SandyShoresBeek.lua
+++ b/Config/Stations/Med/SandyShoresBeek.lua
@@ -27,5 +27,8 @@ MedSandy = {
     help = {
 
     },
+    tp = {
+
+    },
   },
 }

--- a/Config/Stations/Med/SandyShoresFDVanilla.lua
+++ b/Config/Stations/Med/SandyShoresFDVanilla.lua
@@ -26,5 +26,11 @@ FireSandy = {
     help = {
 
     },
+    tp = {
+      {x=1686.28, y=3593.23, z=35.57, handle='SandyFire'},
+    },
+    weap = {
+      {x=1690.24, y=3608.35, z=35.36, handle='SandyFire'},
+    },
   },
 }

--- a/Config/Stations/Med/SandyShoresVanilla.lua
+++ b/Config/Stations/Med/SandyShoresVanilla.lua
@@ -26,5 +26,11 @@ MedSandy = {
     help = {
 
     },
+    tp = {
+
+    },
+    weap = {
+      {x=1814.23, y=3673.82, z=34.28, handle='SandyMed'},
+    },
   },
 }

--- a/Config/Stations/Other/BolingbrokeVanilla.lua
+++ b/Config/Stations/Other/BolingbrokeVanilla.lua
@@ -35,6 +35,9 @@ OthBolingbroke = {
     weap = {
       {x=1817.7, y=2594.52, z=45.72, handle='Bolingbroke'},
     },
+    tp = {
+
+    },
   },
   corspawn = {
 

--- a/Config/Stations/Other/CoronerOfficeVanilla.lua
+++ b/Config/Stations/Other/CoronerOfficeVanilla.lua
@@ -35,6 +35,9 @@ OthCoronerOffice = {
     weap = {
 
     },
+    tp = {
+
+    },
   },
   corspawn = {
     {x=228.89, y=-1430.88, z=29.34, angle=57.42, xa=212.21, ya=-1434.29, za=29.34, aa=237.81, handle='CoronerOfficeLS', name='Los Santos County Coroner Office'},

--- a/Config/Stations/Police/BeaverBushSmokey.lua
+++ b/Config/Stations/Police/BeaverBushSmokey.lua
@@ -13,7 +13,7 @@ PolBeaverBush = {
 
     },
     cloth = {
-      {x=386.26, y=796.32, z=191.38, handle='BeaverBushSAPR'},
+      {x=386.26, y=796.32, z=190.38, handle='BeaverBushSAPR'},
     },
     evidence = {
 
@@ -34,6 +34,12 @@ PolBeaverBush = {
     },
     weap = {
       {x=387.27, y=799.73, z=190.38, handle='BeaverBushSAPR'},
+    },
+    delete = {
+      {x=371.04, y=791.12, z=187.44, handle='BeaverBushSAPR'},
+    },
+    tp = {
+      {x=381.69, y=802.53, z=187.63, handle='BeaverBushSAPR'},
     },
   },
   corspawn = {

--- a/Config/Stations/Police/BeaverBushVanilla.lua
+++ b/Config/Stations/Police/BeaverBushVanilla.lua
@@ -35,6 +35,12 @@ PolBeaverBush = {
     weap = {
       {x=387.01, y=791.36, z=187.69, handle='BeaverBushSAPR'},
     },
+    delete = {
+      {x=370.49, y=792.35, z=187.5, handle='BeaverBushSAPR'},
+    },
+    tp = {
+      {x=383.37, y=802.53, z=187.63, handle='BeaverBushSAPR'},
+    },
   },
   corspawn = {
 

--- a/Config/Stations/Police/DavisVanilla.lua
+++ b/Config/Stations/Police/DavisVanilla.lua
@@ -45,6 +45,12 @@ PolDavis = {
       {x=360.53, y=-1584.36, z=29.29, handle='DavisLSPD'},
       {x=371.83, y=-1626.21, z=29.29, handle='DavisSWAT'},
     },
+    delete = {
+
+    },
+    tp = {
+
+    },
   },
   corspawn = {
     {x=368.48, y=-1568.78, z=29.26, angle=232.39, xa=395.25, ya=-1570.28, za=29.34, aa=49.09, handle='DavisLSPD', name='LSPD Station Davis'},

--- a/Config/Stations/Police/DelPerroPablito.lua
+++ b/Config/Stations/Police/DelPerroPablito.lua
@@ -1,0 +1,48 @@
+PolDelPerro = {
+  handles = {
+    DelPerroLSPD = {handle='DelPerroLSPD', name='lspd', stationname = "Los Santos Police Department Del Perro Pier", shortname = "Del Perro Pier"},
+  },
+  blips = {
+    {x=-1632.33, y=-1013.57, z=13.11, sprite=60, colour=3, alpha=255, name='LSPD Station'},
+  },
+  tps = {
+    {x=-1633.00, y=-1010.8, z=13.09, handle='DelPerroLSPD'},
+  },
+  markers = {
+    arrest = {
+      {x=-1611.88, y=-1023.41, z=13.15, handle='DelPerroLSPD'},
+    },
+    cloth = {
+      {x=-1622.89, y=-1034.01, z=13.15, handle='DelPerroLSPD'},
+    },
+    evidence = {
+      {x=-1627.44, y=-1026.12, z=13.15, handle='DelPerroLSPD'},
+    },
+    garage = {
+      marker = {
+        {x=-1635.38, y=-1023.73, z=13.15, handle='DelPerroLSPD'},
+      },
+      spawnpoint = {
+        {x=-1624.31, y=-1014.12, z=14.15, angle=323.73, handle='DelPerroLSPD'},
+      },
+    },
+    heal = {
+
+    },
+    help = {
+
+    },
+    weap = {
+      {x=-1618.79, y=-1029.75, z=13.15, handle='DelPerroLSPD'},
+    },
+    delete = {
+      {x=-1620.26, y=-1013.33, z=13.15, handle='DelPerroLSPD'},
+    },
+    tp = {
+      {x=-1634.79, y=-1029.11, z=13.15, handle='DelPerroLSPD'},
+    },
+  },
+  corspawn = {
+
+  },
+}

--- a/Config/Stations/Police/DelPerroVanilla.lua
+++ b/Config/Stations/Police/DelPerroVanilla.lua
@@ -35,6 +35,12 @@ PolDelPerro = {
     weap = {
       {x=-1626.07, y=-1019.26, z=13.16, handle='DelPerroLSPD'},
     },
+    delete = {
+      {x=-1620.26, y=-1013.33, z=13.15, handle='DelPerroLSPD'},
+    },
+    tp = {
+      {x=-1634.79, y=-1029.11, z=13.15, handle='DelPerroLSPD'},
+    },
   },
   corspawn = {
 

--- a/Config/Stations/Police/LaMesaMatus.lua
+++ b/Config/Stations/Police/LaMesaMatus.lua
@@ -1,0 +1,65 @@
+PolLaMesa = {
+  handles = {
+    LaMesaLSPD = {handle='LaMesaLSPD', name='lspd', stationname = "Los Santos Police Department La Mesa", shortname = "La Mesa"},
+    LaMesaSASP = {handle='LaMesaSASP', name='sasp', stationname = "San Andreas Highway Patrol Station La Mesa", shortname = "La Mesa"},
+    LaMesaSWAT = {handle='LaMesaSWAT', name='swat', stationname = "SWAT Base La Mesa", shortname = "La Mesa"},
+  },
+  blips = {
+    {x=824.32, y=-1290.22, z=28.24, sprite=60, colour=40, alpha=255, name='SWAT Station'},
+    {x=824.32, y=-1290.22, z=28.24, sprite=60, colour=0, alpha=255, name='SASP Station'},
+    {x=824.32, y=-1290.22, z=28.24, sprite=60, colour=3, alpha=255, name='LSPD Station'},
+  },
+  tps = {
+    {x=812.47, y=-1289.88, z=26.29, handle='LaMesaLSPD'},
+    {x=812.47, y=-1289.88, z=26.29, handle='LaMesaSASP'},
+    {x=812.47, y=-1289.88, z=26.29, handle='LaMesaSWAT'},
+  },
+  markers = {
+    arrest = {
+      {x=834.82, y=-1303.32, z=24.32, handle='LaMesaLSPD'},
+    },
+    cloth = {
+      {x=830.3, y=-1285.26, z=24.32, handle='LaMesaLSPD'},
+      {x=832.2, y=-1281.92, z=24.32, handle='LaMesaSASP'},
+      {x=831.73, y=-1278.05, z=24.32, handle='LaMesaSWAT'},
+      {x=844.65, y=-1281.88, z=24.32, handle='LaMesaLSPD'},
+      {x=844.95, y=-1286.25, z=24.32, handle='LaMesaSASP'},
+      {x=845.6, y=-1278.05, z=24.32, handle='LaMesaSWAT'},
+    },
+    evidence = {
+      {x=840.53, y=-1293.92, z=24.32, handle='LaMesaLSPD'},
+    },
+    garage = {
+      marker = {
+        {x=837.69, y=-1374.57, z=26.31, handle='LaMesaLSPD'},
+        {x=852.24, y=-1300.69, z=24.32, handle='LaMesaSASP'},
+        {x=863.21, y=-1354.29, z=26.08, handle='LaMesaSWAT'},
+      },
+      spawnpoint = {
+        {x=832.4, y=-1370.61, z=26.13, angle=358.00, handle='LaMesaLSPD'},
+        {x=857.1, y=-1310.63, z=23.95, angle=2.19, handle='LaMesaSASP'},
+        {x=869.72, y=-1350.24, z=26.14, angle=89.67, handle='LaMesaSWAT'},
+      },
+    },
+    heal = {
+
+    },
+    help = {
+
+    },
+    weap = {
+      {x=834.34, y=-1294.81, z=24.32, handle='LaMesaLSPD'},
+      {x=842.69, y=-1307.65, z=24.32, handle='LaMesaSASP'},
+      {x=835.08, y=-1299.3, z=24.32, handle='LaMesaSWAT'},
+    },
+    delete = {
+      {x=826.76, y=-1312.9, z=26.13, handle='LaMesaLSPD'},
+    },
+    tp = {
+      {x=846.59, y=-1281.01, z=28.23, handle='LaMesaLSPD'},
+    },
+  },
+  corspawn = {
+    {x=805.91, y=-1341.60, z=26.24, angle=0.0, xa=791.14, ya=-1296.48, za=26.26, aa=175.88, handle='LaMesaLSPD', name='LSPD Station La Mesa'},
+  },
+}

--- a/Config/Stations/Police/LaMesaVanilla.lua
+++ b/Config/Stations/Police/LaMesaVanilla.lua
@@ -49,6 +49,12 @@ PolLaMesa = {
       {x=837.17, y=-1374.39, z=26.31, handle='LaMesaSASP'},
       {x=847.22, y=-1276.27, z=26.47, handle='LaMesaSWAT'},
     },
+    delete = {
+      {x=863.09, y=-1350.21, z=26.06, handle='LaMesaLSPD'},
+    },
+    tp = {
+      {x=847.76, y=-1317.52, z=26.44, handle='LaMesaLSPD'},
+    },
   },
   corspawn = {
     {x=805.91, y=-1341.60, z=26.24, angle=0.0, xa=791.14, ya=-1296.48, za=26.26, aa=175.88, handle='LaMesaLSPD', name='LSPD Station La Mesa'},

--- a/Config/Stations/Police/MissionRowSLB.lua
+++ b/Config/Stations/Police/MissionRowSLB.lua
@@ -38,6 +38,12 @@ PolMissionRow = {
     weap = {
       {x=452.17, y=-980.26, z=30.69, handle='MissionRowLSPD'},
     },
+    delete = {
+      {x=433.9, y=-1011.72, z=28.7, handle='MissionRowLSPD'},
+    },
+    tp = {
+      {x=462.83, y=-1018.26, z=32.98, handle='MissionRowLSPD'},
+    },
   },
   corspawn = {
     {x=401.83, y=-1008.18, z=29.39, angle=0.0, handle='MissionRowLSPD', name='LSPD Station Mission Row'},

--- a/Config/Stations/Police/MissionRowVanilla.lua
+++ b/Config/Stations/Police/MissionRowVanilla.lua
@@ -38,6 +38,12 @@ PolMissionRow = {
     weap = {
       {x=452.17, y=-980.26, z=30.69, handle='MissionRowLSPD'},
     },
+    delete = {
+      {x=433.37, y=-1011.18, z=28.69, handle='MissionRowLSPD'},
+    },
+    tp = {
+      {x=451.0, y=-976.62, z=30.69, handle='MissionRowLSPD'},
+    },
   },
   corspawn = {
     {x=401.83, y=-1008.18, z=29.39, angle=0.0, xa=396.51, ya=-1003.12, za=29.40, aa=180.0, handle='MissionRowLSPD', name='LSPD Station Mission Row'},

--- a/Config/Stations/Police/PaletoBayMatus.lua
+++ b/Config/Stations/Police/PaletoBayMatus.lua
@@ -7,7 +7,7 @@ PolPaleto = {
   },
   blips = {
     {x=-445.25, y=6012.7, z=40.15, sprite=60, colour=40, alpha=255, name='SWAT Station'},
-    {x=-445.25, y=6012.7, z=40.15, sprite=60, colour=5, alpha=255, name='BCSO Station'},
+    {x=-445.25, y=6012.7, z=40.15, sprite=60, colour=5, alpha=255, name='LSSD Station'},
     {x=-445.25, y=6012.7, z=40.15, sprite=60, colour=0, alpha=255, name='SASP Station'},
   },
   tps = {
@@ -51,6 +51,12 @@ PolPaleto = {
       {x=-437.64, y=5989.05, z=31.72, handle='PaletoBCSO'},
       {x=-436.09, y=6005.58, z=31.72, handle='PaletoSASP'},
       {x=-438.62, y=6002.82, z=31.72, handle='PaletoSWAT'},
+    },
+    delete = {
+      {x=-477.2, y=6014.38, z=31.34, handle='PaletoBCSO'},
+    },
+    tp = {
+      {x=-447.58, y=5986.11, z=31.49, handle='PaletoBCSO'},
     },
   },
   corspawn = {

--- a/Config/Stations/Police/PaletoBayVanilla.lua
+++ b/Config/Stations/Police/PaletoBayVanilla.lua
@@ -8,7 +8,7 @@ PolPaleto = {
   },
   blips = {
     {x=-445.25, y=6012.7, z=40.15, sprite=60, colour=40, alpha=255, name='SWAT Station'},
-    {x=-445.25, y=6012.7, z=40.15, sprite=60, colour=5, alpha=255, name='BCSO Station'},
+    {x=-445.25, y=6012.7, z=40.15, sprite=60, colour=5, alpha=255, name='LSSD Station'},
     {x=-445.25, y=6012.7, z=40.15, sprite=60, colour=0, alpha=255, name='SASP Station'},
   },
   tps = {
@@ -52,6 +52,12 @@ PolPaleto = {
       {x=-442.55, y=6012.16, z=31.92, handle='PaletoBCSO'},
       {x=-452.16, y=6005.9, z=31.84, handle='PaletoSASP'},
       {x=-447.14, y=6001.01, z=31.69, handle='PaletoSWAT'},
+    },
+    delete = {
+      {x=-477.23, y=6013.92, z=31.33, handle='PaletoBCSO'},
+    },
+    tp = {
+      {x=-447.58, y=5986.11, z=31.49, handle='PaletoBCSO'},
     },
   },
   corspawn = {

--- a/Config/Stations/Police/RockfordVanilla.lua
+++ b/Config/Stations/Police/RockfordVanilla.lua
@@ -42,6 +42,12 @@ PolRockford = {
       {x=-561.31, y=-132.54, z=38.03, handle='RockfordLSPD'},
       {x=-578.7, y=-133.71, z=35.82, handle='RockfordSWAT'},
     },
+    delete = {
+      {x=-546.08, y=-139.69, z=38.6, handle='RockfordLSPD'},
+    },
+    tp = {
+      {x=-560.22, y=-177.79, z=38.06, handle='RockfordLSPD'},
+    },
   },
   corspawn = {
     {x=-563.73, y=-153.27, z=38.09, angle=112.09, xa=-562.97, ya=-158.53, za=38.13, aa=290.86, handle='RockfordLSPD', name='LSPD Station Rockford Hills'},

--- a/Config/Stations/Police/SandyShoresBamboozled.lua
+++ b/Config/Stations/Police/SandyShoresBamboozled.lua
@@ -3,7 +3,7 @@ PolSandy = {
     SandyShoresBCSO = {handle='SandyShoresBCSO', name='bcso', stationname = "Sheriff Office Sandy Shores", shortname = "Sandy Shores"},
   },
   blips = {
-    {x=1852.92, y=3687.03, z=34.27, sprite=60, colour=5, alpha=255, name='BCSO Station'},
+    {x=1852.92, y=3687.03, z=34.27, sprite=60, colour=5, alpha=255, name='LSSD Station'},
   },
   tps = {
     {x=1863.75, y=3683.29, z=33.78, handle='SandyShoresBCSO'},
@@ -34,6 +34,12 @@ PolSandy = {
     },
     weap = {
       {x=1860.51, y=3692.96, z=34.25, handle='SandyShoresBCSO'},
+    },
+    delete = {
+      {x=1866.48, y=3688.3, z=34.27, handle='SandyShoresBCSO'},
+    },
+    tp = {
+      {x=1821.8, y=3683.82, z=34.28, handle='SandyShoresBCSO'},
     },
   },
   corspawn = {

--- a/Config/Stations/Police/SandyShoresVanilla.lua
+++ b/Config/Stations/Police/SandyShoresVanilla.lua
@@ -3,7 +3,7 @@ PolSandy = {
     SandyShoresBCSO = {handle='SandyShoresBCSO', name='bcso', stationname = "Sheriff Office Sandy Shores", shortname = "Sandy Shores"},
   },
   blips = {
-    {x=1852.92, y=3687.03, z=34.27, sprite=60, colour=5, alpha=255, name='BCSO Station'},
+    {x=1852.92, y=3687.03, z=34.27, sprite=60, colour=5, alpha=255, name='LSSD Station'},
   },
   tps = {
     {x=1863.75, y=3683.29, z=33.78, handle='SandyShoresBCSO'},
@@ -34,6 +34,12 @@ PolSandy = {
     },
     weap = {
       {x=1851.02, y=3683.31, z=34.47, handle='SandyShoresBCSO'},
+    },
+    delete = {
+      {x=1866.56, y=3688.11, z=34.27, handle='SandyShoresBCSO'},
+    },
+    tp = {
+      {x=1821.99, y=3683.67, z=34.28, handle='SandyShoresBCSO'},
     },
   },
   corspawn = {

--- a/Config/Stations/Police/VespucciBeachVanilla.lua
+++ b/Config/Stations/Police/VespucciBeachVanilla.lua
@@ -35,6 +35,12 @@ PolVespucciBeach = {
     weap = {
       {x=-1317.87, y=-1529.29, z=4.42, handle='VespucciBeachLSPD'}
     },
+    delete = {
+
+    },
+    tp = {
+
+    },
   },
   corspawn = {
 

--- a/Config/Stations/Police/VespucciVanilla.lua
+++ b/Config/Stations/Police/VespucciVanilla.lua
@@ -45,6 +45,12 @@ PolVespucci = {
       {x=-1108.69, y=-845.55, z=19.32, handle='VespucciLSPD'},
       {x=-1109.7, y=-853.8, z=13.53, handle='VespucciSWAT'},
     },
+    delete = {
+
+    },
+    tp = {
+      {x=-1036.57, y=-844.22, z=8.32, handle='VespucciLSPD'},
+    },
   },
   corspawn = {
     {x=-1145.59, y=-826.04, z=14.77, angle=309.96, xa=-1124.69, ya=-793.47, za=17.37, aa=128.82, handle='VespucciLSPD', name='LSPD Station Vespucci'},

--- a/Config/Stations/Police/VinewoodVanilla.lua
+++ b/Config/Stations/Police/VinewoodVanilla.lua
@@ -36,7 +36,13 @@ PolVinewood = {
 
     },
     weap = {
-      {x=639.82, y=0.9, z=82.79, handle='VinewoodLSPD'}
+      {x=639.82, y=0.9, z=82.79, handle='VinewoodLSPD'},
+    },
+    delete = {
+      {x=531.96, y=-38.12, z=70.68, handle='VinewoodLSPD'},
+    },
+    tp = {
+      {x=632.4, y=-19.0, z=81.89, handle='VinewoodLSPD'},
     },
   },
   corspawn = {

--- a/Config/Stations/Tow/AutoExoticVinewood.lua
+++ b/Config/Stations/Tow/AutoExoticVinewood.lua
@@ -23,6 +23,18 @@ TowVinewood = {
     help = {
 
     },
+    repair = {
+      {x=547.89, y=-206.43, z=54.14, handle='VinewoodDPOS'},
+    },
+    delete = {
+      {x=534.42, y=-168.28, z=54.65, handle='VinewoodDPOS'},
+    },
+    tp = {
+      {x=547.66, y=-173.69, z=54.48, handle='VinewoodDPOS'},
+    },
+    weap = {
+      {x=548.58, y=-190.49, z=54.48, handle='VinewoodDPOS'},
+    },
   },
   towspawn = {
     {x=530.75, y=-225.58, z=50.36, angle=11.28, xa=543.19, ya=-84.56, za=67.38, aa=123.07, handle='VinewoodDPOS'},

--- a/Config/Stations/Tow/AutoRepairsMirrorPark.lua
+++ b/Config/Stations/Tow/AutoRepairsMirrorPark.lua
@@ -23,6 +23,18 @@ TowMirrorPark = {
     help = {
 
     },
+    repair = {
+      {x=1140.84, y=-776.1, z=57.6, handle='MirrorParkDPOS'},
+    },
+    delete = {
+      {x=1153.26, y=-776.35, z=57.6, handle='MirrorParkDPOS'},
+    },
+    tp = {
+      {x=1140.86, y=-792.92, z=57.6, handle='MirrorParkDPOS'},
+    },
+    weap = {
+      {x=1154.09, y=-785.47, z=57.6, handle='MirrorParkDPOS'},
+    },
   },
   towspawn = {
     {x=1136.32, y=-762.04, z=57.74, angle=267.25, xa=1153.52, ya=-756.54, za=57.80, aa=90.31, handle='MirrorParkDPOS'},

--- a/Config/Stations/Tow/AutoRepairsSandy.lua
+++ b/Config/Stations/Tow/AutoRepairsSandy.lua
@@ -23,6 +23,18 @@ TowSandy = {
     help = {
 
     },
+    repair = {
+      {x=2515.74, y=4119.95, z=38.62, handle='SandyDPOS'},
+    },
+    delete = {
+      {x=2502.44, y=4089.29, z=38.58, handle='SandyDPOS'},
+    },
+    tp = {
+      {x=2525.42, y=4097.98, z=38.63, handle='SandyDPOS'},
+    },
+    weap = {
+      {x=2519.48, y=4113.25, z=38.63, handle='SandyDPOS'},
+    },
   },
   towspawn = {
     {x=2492.10, y=4086.91, z=37.53, angle=335.83, xa=2498.00, ya=4112.42, za=37.89, aa=155.13, handle='SandyDPOS'},

--- a/Config/Stations/Tow/BeekersGarageVanilla.lua
+++ b/Config/Stations/Tow/BeekersGarageVanilla.lua
@@ -23,6 +23,18 @@ TowBeekers = {
     help = {
 
     },
+    repair = {
+      {x=110.52, y=6626.63, z=31.79, handle='PaletoDPOS'},
+    },
+    delete = {
+      {x=122.52, y=6628.26, z=31.92, handle='PaletoDPOS'},
+    },
+    tp = {
+      {x=102.4, y=6623.88, z=31.83, handle='PaletoDPOS'},
+    },
+    weap = {
+      {x=102.47, y=6615.6, z=32.44, handle='PaletoDPOS'},
+    },
   },
   towspawn = {
     {x=100.61, y=6578.23, z=31.62, angle=224.27, xa=105.23, ya=6581.24, za=31.59, aa=42.74, handle='PaletoDPOS', name='Beekers Garage Paleto'},

--- a/Config/Stations/Tow/BennysVanilla.lua
+++ b/Config/Stations/Tow/BennysVanilla.lua
@@ -23,6 +23,18 @@ TowBennys = {
     help = {
 
     },
+    repair = {
+      {x=-210.81, y=-1324.2, z=30.89, handle='Bennys'},
+    },
+    delete = {
+      {x=-214.24, y=-1317.0, z=30.89, handle='Bennys'},
+    },
+    tp = {
+      {x=-215.08, y=-1313.72, z=34.7, handle='Bennys'},
+    },
+    weap = {
+      {x=-214.61, y=-1339.3, z=34.89, handle='Bennys'},
+    },
   },
   towspawn = {
     {x=-267.43, y=-1294.78, z=31.21, angle=359.53, xa=-281.69, ya=-1293.75, za=31.26, aa=178.9, handle='Bennys', name='Bennys Original Motorworks'},

--- a/Config/Stations/Tow/DPOSDavisVanilla.lua
+++ b/Config/Stations/Tow/DPOSDavisVanilla.lua
@@ -23,6 +23,18 @@ TowDavis = {
     help = {
 
     },
+    repair = {
+      {x=403.41, y=-1644.49, z=29.29, handle='DavisDPOS'},
+    },
+    delete = {
+      {x=396.96, y=-1633.15, z=29.29, handle='DavisDPOS'},
+    },
+    tp = {
+      {x=389.71, y=-1641.64, z=29.25, handle='DavisDPOS'},
+    },
+    weap = {
+      {x=394.54, y=-1646.48, z=29.29, handle='DavisDPOS'},
+    },
   },
   towspawn = {
     {x=387.41, y=-1584.61, z=29.26, angle=228.49, xa=417.41, ya=-1588.49, za=29.34, aa=49.22, handle='DavisDPOS', name='DPOS Station Davis'},

--- a/Config/Stations/Tow/DPOSVespucciVanilla.lua
+++ b/Config/Stations/Tow/DPOSVespucciVanilla.lua
@@ -23,6 +23,18 @@ TowVespucci = {
     help = {
 
     },
+    repair = {
+      {x=-1059.95, y=-851.47, z=4.87, handle='VespucciDPOS'},
+    },
+    delete = {
+      {x=-1038.5, y=-851.55, z=5.04, handle='VespucciDPOS'},
+    },
+    tp = {
+
+    },
+    weap = {
+      {x=-1041.38, y=-845.37, z=5.04, handle='VespucciDPOS'},
+    },
   },
   towspawn = {
     {x=-1053.94, y=-886.05, z=4.91, angle=119.46, xa=-1049.61, ya=-889.97, za=4.95, aa=297.45, handle='VespucciDPOS', name='DPOS Station Vespucci'},

--- a/Config/Stations/Tow/LSCAirportVanilla.lua
+++ b/Config/Stations/Tow/LSCAirportVanilla.lua
@@ -23,6 +23,18 @@ TowLSIA = {
     help = {
 
     },
+    repair = {
+      {x=-1156.16, y=-2007.23, z=13.18, handle='LSCLSIA'},
+    },
+    delete = {
+      {x=-1157.71, y=-2017.65, z=13.18, handle='LSCLSIA'},
+    },
+    tp = {
+      {x=-1167.44, y=-2013.55, z=13.23, handle='LSCLSIA'},
+    },
+    weap = {
+      {x=-1141.31, y=-2005.99, z=13.18, handle='LSCLSIA'},
+    },
   },
   towspawn = {
     {x=-1097.88, y=-1980.73, z=13.12, angle=179.9, xa=-1092.68, ya=-1980.84, za=13.14, aa=350.84, handle='LSCLSIA', name='Los Santos Customs Airport'},

--- a/Config/Stations/Tow/LSCBurtonVanilla.lua
+++ b/Config/Stations/Tow/LSCBurtonVanilla.lua
@@ -23,6 +23,18 @@ TowBurton = {
     help = {
 
     },
+    repair = {
+      {x=-338.29, y=-137.54, z=39.01, handle='LSCCentral'},
+    },
+    delete = {
+      {x=-327.51, y=-133.71, z=39.01, handle='LSCCentral'},
+    },
+    tp = {
+      {x=-326.98, y=-144.67, z=39.06, handle='LSCCentral'},
+    },
+    weap = {
+      {x=-3440.3, y=-124.62, z=39.01, handle='LSCCentral'},
+    },
   },
   towspawn = {
     {x=-351.06, y=-187.97, z=39.07, angle=109.95, xa=-370.19, ya=-212.36, za=36.85, aa=286.69, handle='LSCCentral', name='Los Santos Customs Burton'},

--- a/Config/Stations/Tow/LSCHarmonyVanilla.lua
+++ b/Config/Stations/Tow/LSCHarmonyVanilla.lua
@@ -23,6 +23,18 @@ TowHarmony = {
     help = {
 
     },
+    repair = {
+      {x=1175.11, y=2639.82, z=37.75, handle='LSCHarmony'},
+    },
+    delete = {
+      {x=1187.83, y=2651.77, z=37.84, handle='LSCHarmony'},
+    },
+    tp = {
+      {x=1182.61, y=2637.83, z=37.8, handle='LSCHarmony'},
+    },
+    weap = {
+      {x=1187.69, y=2636.44, z=38.4, handle='LSCHarmony'},
+    },
   },
   towspawn = {
     {x=1209.07, y=2678.73, z=38.7, angle=268.13, xa=1208.68, ya=2685.2, za=37.71, aa=85.39, handle='LSCHarmony', name='Los Santos Customs Harmony'},

--- a/Config/Stations/Tow/LSCLaMesaVanilla.lua
+++ b/Config/Stations/Tow/LSCLaMesaVanilla.lua
@@ -23,6 +23,18 @@ TowLaMesa = {
     help = {
 
     },
+    repair = {
+      {x=732.46, y=-1088.88, z=22.17, handle='LSCLaMesa'},
+    },
+    delete = {
+      {x=720.88, y=-1069.28, z=23.06, handle='LSCLaMesa'},
+    },
+    tp = {
+      {x=735.76, y=-1071.43, z=22.23, handle='LSCLaMesa'},
+    },
+    weap = {
+      {x=728.49, y=-1074.04, z=22.17, handle='LSCLaMesa'},
+    },
   },
   towspawn = {
     {x=791.34, y=-1073.81, z=28.4, angle=5.7, xa=786.00, ya=-1073.72, za=28.39, aa=182.18, handle='LSCLaMesa', name='Los Santos Customs La Mesa'},

--- a/Config/Stations/stations_cl.lua
+++ b/Config/Stations/stations_cl.lua
@@ -171,13 +171,7 @@ end
 
 -- Weap-coords init
 list_weap_coords = {}
-for i, Station in ipairs(PolStations) do
-  for j, weappoint in ipairs(Station.markers.weap) do
-    table.insert(list_weap_coords, weappoint)
-  end
-end
-
-for i, Station in ipairs(OthStations) do
+for i, Station in ipairs(Stations) do
   for j, weappoint in ipairs(Station.markers.weap) do
     table.insert(list_weap_coords, weappoint)
   end
@@ -240,6 +234,35 @@ list_tp_coords = {}
 for i, Station in ipairs(Stations) do
   for j, tppoint in pairs(Station.tps) do
     table.insert(list_tp_coords, tppoint)
+  end
+end
+
+-- repair-coords init
+list_repair_coords = {}
+for i, Station in ipairs(TowStations) do
+  for j, repairpoint in pairs(Station.markers.repair) do
+    table.insert(list_repair_coords, repairpoint)
+  end
+end
+
+-- delete-coords init
+list_delete_coords = {}
+for i, Station in ipairs(TowStations) do
+  for j, deletepoint in pairs(Station.markers.delete) do
+    table.insert(list_delete_coords, deletepoint)
+  end
+end
+for i, Station in ipairs(PolStations) do
+  for j, deletepoint in pairs(Station.markers.delete) do
+    table.insert(list_delete_coords, deletepoint)
+  end
+end
+
+-- tp-marker-coords init
+list_tpmarker_coords = {}
+for i, Station in ipairs(Stations) do
+  for j, tpmarkerpoint in pairs(Station.markers.tp) do
+    table.insert(list_tpmarker_coords, tpmarkerpoint)
   end
 end
 

--- a/Config/Wardrobes/Files/BCFD/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/BCFD/AccessoiresEUP.lua
@@ -7,18 +7,20 @@ BCFDAccessoires = {
     Name = "Firefighter",
     Male = {
       Ranked = true,
-      RankList = {1,1,1,1,2,2,2,2,2},
+      RankList = {1,1,1,1,2,2,2,3,3},
       ClothList = {
-        {45,6,{} },
-        {45,7,{} },
+        {45,3,{} },
+        {45,4,{} },
+        {45,5,{} },
       }
     },
     Female = {
       Ranked = true,
-      RankList = {1,1,1,1,2,2,2,2,2},
+      RankList = {1,1,1,1,2,2,2,3,3},
       ClothList = {
-        {44,6,{} },
-        {44,7,{} },
+        {44,3,{} },
+        {44,4,{} },
+        {44,5,{} },
       }
     },
   },
@@ -32,14 +34,83 @@ BCFDAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {18,0,{} },
+        {17,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {17,0,{} },
+        {16,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 10,
+    Category = "Sticker",
+    CategoryIndex = 0,
+    Name = "Cloth Label",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {58,1,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {66,1,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 5,
+    Category = "Badge",
+    CategoryIndex = 0,
+    Name = "Badge",
+    Male = {
+      Ranked = true,
+      RankList = {1,2,2,1,3,3,3,4,4},
+      ClothList = {
+        {37,1,{} },
+        {37,0,{} },
+        {37,2,{} },
+        {37,4,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,2,2,1,3,3,3,4,4},
+      ClothList = {
+        {37,1,{} },
+        {37,0,{} },
+        {37,2,{} },
+        {37,4,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 5,
+    Category = "Vest",
+    CategoryIndex = 2,
+    Name = "Search and Rescue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {8,4,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {9,4,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/BCFD/TopsEUP.lua
+++ b/Config/Wardrobes/Files/BCFD/TopsEUP.lua
@@ -1,148 +1,217 @@
 BCFDTops = {
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Class C", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {47,0,{{3,0,0},{8,15,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {74, 2, {{3,11,0},{5,37,1},{8,15,0},{9,0,0},{10,0,0}} },
+        {74, 3, {{3,11,0},{5,37,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {74, 2, {{3,11,0},{5,37,2},{8,15,0},{9,0,0},{10,0,0}} },
+        {74, 2, {{3,11,0},{5,37,4},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,2,{{3,14,0},{8,14,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {25, 3, {{3,9,0},{5,37,1},{8,14,0},{9,0,0},{10,0,0}} },
+        {25, 2, {{3,9,0},{5,37,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {25, 3, {{3,9,0},{5,37,2},{8,14,0},{9,0,0},{10,0,0}} },
+        {25, 3, {{3,9,0},{5,37,4},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {47,1,{{3,0,0},{8,15,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {75, 2, {{3,4,0},{5,37,1},{8,15,0},{9,0,0},{10,0,0}} },
+        {75, 3, {{3,4,0},{5,37,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {75, 2, {{3,4,0},{5,37,2},{8,15,0},{9,0,0},{10,0,0}} },
+        {75, 2, {{3,4,0},{5,37,4},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,3,{{3,14,0},{8,14,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {26, 3, {{3,3,0},{5,37,1},{8,14,0},{9,0,0},{10,0,0}} },
+        {26, 2, {{3,3,0},{5,37,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {26, 3, {{3,3,0},{5,37,2},{8,14,0},{9,0,0},{10,0,0}} },
+        {26, 3, {{3,3,0},{5,37,4},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T4",
-    CategoryIndex = 4,
-    Name = "Hi Vis",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {71,0,{{3,4,0},{8,15,0},{9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {67,0,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T6",
-    CategoryIndex = 6,
-    Name = "Firefighter",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {77,0,{{3,4,0},{8,15,0},{9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {64,0,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T6",
-    CategoryIndex = 6,
-    Name = "Firefighter",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {77,1,{{3,4,0},{8,15,0},{9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {64,1,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Class A", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {250,0,{{3,0,0},{8,15,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {118, 2, {{3,4,0},{5,37,1},{8,15,0},{9,0,0},{10,0,0}} },
+        {118, 3, {{3,4,0},{5,37,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {118, 2, {{3,4,0},{5,37,2},{8,15,0},{9,0,0},{10,0,0}} },
+        {118, 2, {{3,4,0},{5,37,4},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {258,0,{{3,14,0},{8,14,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {18, 2, {{3,3,0},{5,37,1},{8,14,0},{9,0,0},{10,0,0}} },
+        {18, 3, {{3,3,0},{5,37,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {18, 2, {{3,3,0},{5,37,2},{8,14,0},{9,0,0},{10,0,0}} },
+        {18, 2, {{3,3,0},{5,37,4},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {73, 16, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {224, 22, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Pullover", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {239, 13, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {239, 14, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,1,1,1,1,1
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {223, 13, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {223, 14, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,1,1,1,1,1
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Eagle", -- the item will be categorized inside this category
+    CategoryIndex = 3,
+    Name = "Eagle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {108, 6, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {99, 6, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Paramedic", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {151, 3, {{3,4,0},{5,0,0},{8,15,0},{9,28,3},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {148, 3, {{3,3,0},{5,0,0},{8,14,0},{9,30,3},{10,0,0}} },
+      },
+      RankList = {
+
+      },
     },
   },
   {
     Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
-    CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {250,1,{{3,0,0},{8,15,0},{9,0,0}} },
+        {28,3,{{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {258,1,{{3,14,0},{8,14,0},{9,0,0}} },
+        {30,3,{{10,0,0}} },
       }
     },
   },

--- a/Config/Wardrobes/Files/BCSO/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/BCSO/AccessoiresEUP.lua
@@ -9,35 +9,14 @@ BCSOAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {8,0,{} },
+        {8,1,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {8,0,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Cap",
-    CategoryIndex = 0,
-    Name = "Cap",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {10,7,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {10,7,{} },
+        {8,1,{} },
       }
     },
   },
@@ -51,14 +30,14 @@ BCSOAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {13,1,{} },
+        {13,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {13,1,{} },
+        {13,0,{} },
       }
     },
   },
@@ -72,14 +51,14 @@ BCSOAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {33,1,{} },
+        {33,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {32,1,{} },
+        {32,0,{} },
       }
     },
   },
@@ -93,14 +72,14 @@ BCSOAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {17,3,{} },
+        {17,2,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {17,3,{} },
+        {17,2,{} },
       }
     },
   },
@@ -114,35 +93,14 @@ BCSOAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {78,2,{} },
+        {78,3,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {77,2,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 0,
-    Name = "Helicopter",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {79,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {78,2,{} },
+        {77,3,{} },
       }
     },
   },
@@ -151,19 +109,19 @@ BCSOAccessoires = {
     ComponentID = 9,
     Category = "Traffic Vest",
     CategoryIndex = 2,
-    Name = "BCSO",
+    Name = "LSSD",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {10,3,{} },
+        {10,1,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {19,3,{} },
+        {19,1,{} },
       }
     },
   },
@@ -177,56 +135,14 @@ BCSOAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {17,0,{} },
+        {21,1,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {21,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Chain",
-    CategoryIndex = 2,
-    Name = "Badge",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {17,4,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {21,4,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Traffic Vest",
-    CategoryIndex = 2,
-    Name = "BCSO",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {18,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,3,{} },
+        {20,1,{} },
       }
     },
   },
@@ -240,14 +156,14 @@ BCSOAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {23,0,{} },
+        {23,1,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {25,0,{} },
+        {25,1,{} },
       }
     },
   },
@@ -261,35 +177,14 @@ BCSOAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {23,4,{} },
+        {23,6,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {25,4,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt in front of Pullover",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {26,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {28,1,{} },
+        {25,6,{} },
       }
     },
   },
@@ -298,44 +193,136 @@ BCSOAccessoires = {
     ComponentID = 10,
     Category = "Rank Insignia",
     CategoryIndex = 0,
-    Name = "Rank Insignia",
+    Name = "Rank Insignia Class C",
     Male = {
       Ranked = true,
-      RankList = {1,1,2,2,3,3,1,1,1,1,1,1},
+      RankList = {1,1,2,3,4,4,5,6,7,8,9,10},
       ClothList = {
         {0,0,{} },
         {1,0,{} },
+        {10,0,{} },
         {2,0,{} },
+        {44,6,{} },
+        {44,7,{} },
+        {44,8,{} },
+        {44,9,{} },
+        {44,10,{} },
+        {43,0,{} },
       }
     },
     Female = {
       Ranked = true,
-      RankList = {1,1,2,2,3,3,1,1,1,1,1,1},
+      RankList = {1,1,2,3,4,4,5,6,7,8,9,10},
       ClothList = {
         {0,0,{} },
+        {1,0,{} },
+        {9,0,{} },
         {2,0,{} },
-        {3,0,{} },
+        {52,6,{} },
+        {52,7,{} },
+        {52,8,{} },
+        {52,9,{} },
+        {52,10,{} },
+        {51,0,{} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 10,
-    Category = "Sticker",
-    CategoryIndex = 1,
-    Name = "Logo",
+    Category = "Rank Insignia",
+    CategoryIndex = 0,
+    Name = "Rank Insignia Class B",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,4,5,6,7,8,9,10},
+      ClothList = {
+        {0,0,{} },
+        {11,0,{} },
+        {11,2,{} },
+        {11,3,{} },
+        {44,6,{} },
+        {44,7,{} },
+        {44,8,{} },
+        {44,9,{} },
+        {44,10,{} },
+        {43,0,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,4,5,6,7,8,9,10},
+      ClothList = {
+        {0,0,{} },
+        {10,0,{} },
+        {10,2,{} },
+        {10,3,{} },
+        {52,6,{} },
+        {52,7,{} },
+        {52,8,{} },
+        {52,9,{} },
+        {52,10,{} },
+        {51,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 10,
+    Category = "Rank Insignia",
+    CategoryIndex = 0,
+    Name = "Rank Insignia Class A",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,4,5,6,7,8,9,10},
+      ClothList = {
+        {0,0,{} },
+        {11,0,{} },
+        {11,2,{} },
+        {11,3,{} },
+        {45,6,{} },
+        {45,7,{} },
+        {45,8,{} },
+        {45,9,{} },
+        {45,10,{} },
+        {45,11,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,4,5,6,7,8,9,10},
+      ClothList = {
+        {0,0,{} },
+        {10,0,{} },
+        {10,2,{} },
+        {10,3,{} },
+        {53,6,{} },
+        {53,7,{} },
+        {53,8,{} },
+        {53,9,{} },
+        {53,10,{} },
+        {53,11,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 5,
+    Category = "Badges",
+    CategoryIndex = 0,
+    Name = "Badge",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {6,0,{} },
+        {53,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {11,3,{} },
+        {53,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/BCSO/LegsEUP.lua
+++ b/Config/Wardrobes/Files/BCSO/LegsEUP.lua
@@ -9,14 +9,35 @@ BCSOLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {25,2,{{6,51,0}} },
+        {25,0,{{6,25,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {41,0,{{6,52,0}} },
+        {41,1,{{6,25,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Eagle",
+    CategoryIndex = 2,
+    Name = "Standard Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {64,1,{{6,25,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {66,1,{{6,25,0}} },
       }
     },
   },
@@ -30,14 +51,35 @@ BCSOLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {32,2,{{6,30,0}} },
+        {32,2,{{6,13,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {31,2,{{6,9,0}} },
+        {31,2,{{6,26,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Combat Uniform",
+    CategoryIndex = 3,
+    Name = "Standard Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {125,5,{{6,51,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {131,5,{{6,101,0}} },
       }
     },
   },

--- a/Config/Wardrobes/Files/BCSO/TopsEUP.lua
+++ b/Config/Wardrobes/Files/BCSO/TopsEUP.lua
@@ -1,493 +1,701 @@
 BCSOTops = {
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Class C", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      ClothList = {
-        {74, 0, {{3,0,0},{8,15,0},{9,0,0}} },
-        {74, 1, {{3,0,0},{8,15,0},{9,0,0}} },
-        {74, 2, {{3,0,0},{8,15,0},{9,0,0}} },
-        {74, 3, {{3,0,0},{8,15,0},{9,0,0}} },
-        {74, 4, {{3,0,0},{8,15,0},{9,0,0}} },
-        {74, 5, {{3,0,0},{8,15,0},{9,0,0}} },
-        {74, 6, {{3,0,0},{8,15,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,1,0}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,10,0}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,2,0}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {190, 2, {{3,11,0},{5,53,0},{8,15,0},{9,0,0},{10,43,0}} },
       },
       RankList = {
-        1,1,1,1,2,2,3,3,4,5,6,7
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {110, 0, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 1, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 2, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 3, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 4, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 5, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 6, {{3,14,0},{8,14,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,1,0}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,9,0}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,2,0}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {192, 2, {{3,9,0},{5,53,0},{8,14,0},{9,0,0},{10,51,0}} },
       },
       RankList = {
-        1,1,1,1,2,2,3,3,4,5,6,7
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
     },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Long Sleeve",
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      ClothList = {
-        {24, 0, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 1, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 2, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 3, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 4, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 5, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 6, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 7, {{3,4,0},{8,15,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,2}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,3}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {193, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,43,0}} },
       },
       RankList = {
-        1,1,2,2,3,3,4,4,5,6,7,8
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {110, 0, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 1, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 2, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 3, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 4, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 5, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 6, {{3,14,0},{8,14,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,2}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,3}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {195, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,51,0}} },
       },
       RankList = {
-        1,1,1,1,2,2,3,3,4,5,6,7
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Long Sleeve Black Ribbon",
+    Name = "Class A", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      ClothList = {
-        {24, 8, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 9, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 11, {{3,4,0},{8,15,0},{9,0,0}} },
-        {24, 12, {{3,4,0},{8,15,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,2}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,3}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,45,6}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,45,7}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,45,8}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,45,9}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,45,10}} },
+        {200, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,45,11}} },
       },
       RankList = {
-        1,1,1,1,2,2,3,3,3,3,4,4
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {110, 0, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 1, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 2, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 3, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 4, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 5, {{3,14,0},{8,14,0},{9,0,0}} },
-        {110, 6, {{3,14,0},{8,14,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,2}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,3}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,53,6}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,53,7}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,53,8}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,53,9}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,53,10}} },
+        {202, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,53,11}} },
       },
       RankList = {
-        1,1,1,1,2,2,3,3,4,5,6,7
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "T-Shirt",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Standard",
+    Name = "Class B Collar", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      ClothList = {
-        {94, 0, {{3,0,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {85,0, {{3,14,0},{8,14,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,2}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,11,3}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {196, 2, {{3,4,0},{5,53,0},{8,15,0},{9,0,0},{10,43,0}} },
       },
       RankList = {
-
+        1,1,2,3,4,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,2}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,10,3}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {198, 2, {{3,3,0},{5,53,0},{8,14,0},{9,0,0},{10,51,0}} },
+      },
+      RankList = {
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
     },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "T-Shirt",
-    CategoryIndex = 0,
-    Name = "Standard",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {94, 1, {{3,0,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {85,1, {{3,14,0},{8,14,0},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
-    CategoryIndex = 0,
-    Name = "Medium Sleeve",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {133, 0, {{3,0,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {27,1, {{3,0,0},{8,14,0},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Pullover",
-    CategoryIndex = 0,
-    Name = "Green",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {111, 1, {{3,4,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {103,1, {{3,3,0},{8,14,0},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Green",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {156, 0, {{3,4,0},{8,72,1},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {153,0, {{3,3,0},{8,67,1},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Green",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {156, 3, {{3,4,0},{8,72,1},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {153,3, {{3,3,0},{8,67,1},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Blue",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {35, 4, {{3,4,0},{8,72,0},{9,0,0}} },
-      },
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {153,0, {{3,3,0},{8,67,1},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Blue",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {36, 4, {{3,4,0},{8,72,0},{9,0,0}} },
-      },
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {153,3, {{3,3,0},{8,67,1},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T2",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
     CategoryIndex = 2,
-    Name = "Winter",
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      ClothList = {
-        {17, 0, {{3,4,0},{8,15,0},{9,26,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {30, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,0,0}} },
+        {30, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,0,0}} },
+        {30, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,0,0}} },
+        {30, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,0,0}} },
+        {30, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,6}} },
+        {30, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,7}} },
+        {30, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,8}} },
+        {30, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,9}} },
+        {30, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,10}} },
+        {30, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,11}} },
+      },
+      RankList = {
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {21,0, {{3,3,0},{8,14,0},{9,28,1}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {279, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,0,0}} },
+        {279, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,0,0}} },
+        {279, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,0,0}} },
+        {279, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,0,0}} },
+        {279, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,6}} },
+        {279, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,7}} },
+        {279, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,8}} },
+        {279, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,9}} },
+        {279, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,10}} },
+        {279, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,11}} },
       },
       RankList = {
-
+        1,1,2,3,4,4,5,6,7,8,9,10
       },
-    }
+    },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T2",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
     CategoryIndex = 2,
-    Name = "Winter",
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      ClothList = {
-        {17, 2, {{3,4,0},{8,15,0},{9,26,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {187, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,0,0}} },
+        {187, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,6}} },
+        {187, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,7}} },
+        {187, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,8}} },
+        {187, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,9}} },
+        {187, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,10}} },
+        {187, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,11}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,2,3,4,5,6,7
       },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {21,2, {{3,3,0},{8,14,0},{9,28,1}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {189, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,0,0}} },
+        {189, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,6}} },
+        {189, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,7}} },
+        {189, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,8}} },
+        {189, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,9}} },
+        {189, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,10}} },
+        {189, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,11}} },
       },
       RankList = {
-
+        1,1,1,1,1,1,2,3,4,5,6,7
       },
-    }
+    },
   },
   {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
     CategoryIndex = 2,
-    Name = "Radio + Badge",
+    Name = "Winter", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      ClothList = {
-        {43, 2, {} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {16, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,0,0}} },
+        {16, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,6}} },
+        {16, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,7}} },
+        {16, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,8}} },
+        {16, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,9}} },
+        {16, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,10}} },
+        {16, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,11}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,2,3,4,5,6,7
       },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {30,2, {} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {44, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,0,0}} },
+        {44, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,6}} },
+        {44, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,7}} },
+        {44, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,8}} },
+        {44, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,9}} },
+        {44, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,10}} },
+        {44, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,11}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,2,3,4,5,6,7
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {35, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,0,0}} },
+        {35, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,6}} },
+        {35, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,7}} },
+        {35, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,8}} },
+        {35, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,9}} },
+        {35, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,10}} },
+        {35, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,1},{10,45,11}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,2,3,4,5,6,7
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {168, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,0,0}} },
+        {168, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,6}} },
+        {168, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,7}} },
+        {168, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,8}} },
+        {168, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,9}} },
+        {168, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,10}} },
+        {168, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,1},{10,53,11}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,2,3,4,5,6,7
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Eagle", -- the item will be categorized inside this category
+    CategoryIndex = 3,
+    Name = "Eagle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {108, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
 
       },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt",
-    Male = {
-      Ranked = true,
-      ClothList = {
-        {65, 0, {} },
-        {65, 1, {} },
-        {65, 2, {} },
-        {65, 3, {} },
-        {65, 4, {} },
-        {65, 5, {} },
-        {65, 6, {} },
-      },
-      RankList = {
-        1,1,1,1,1,1,2,3,4,5,6,7
-      },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {45, 0, {} },
-        {45, 1, {} },
-        {45, 2, {} },
-        {45, 3, {} },
-        {45, 4, {} },
-        {45, 5, {} },
-        {45, 6, {} },
-      },
-      RankList = {
-        1,1,1,1,1,1,2,3,4,5,6,7
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt + Tie",
-    Male = {
-      Ranked = true,
-      ClothList = {
-        {66, 0, {} },
-        {66, 1, {} },
-        {66, 2, {} },
-        {66, 3, {} },
-        {66, 4, {} },
-        {66, 5, {} },
-        {66, 6, {} },
-      },
-      RankList = {
-        1,1,1,1,1,1,2,3,4,5,6,7
-      },
-    },
-    Female = {
-      Ranked = true,
-      ClothList = {
-        {45, 0, {} },
-        {45, 1, {} },
-        {45, 2, {} },
-        {45, 3, {} },
-        {45, 4, {} },
-        {45, 5, {} },
-        {45, 6, {} },
-      },
-      RankList = {
-        1,1,1,1,1,1,2,3,4,5,6,7
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt in front of Pullover",
-    Male = {
-      Ranked = true,
-      ClothList = {
-        {92, 0, {} },
-        {92, 1, {} },
-        {92, 2, {} },
-        {92, 3, {} },
-        {92, 4, {} },
-        {92, 5, {} },
-        {92, 6, {} },
-      },
-      RankList = {
-        1,1,1,1,1,1,2,3,4,5,6,7
-      },
-    },
-    Female = {
-      Ranked = true,
-      ClothList = {
-        {103, 0, {} },
-        {103, 1, {} },
-        {103, 2, {} },
-        {103, 3, {} },
-        {103, 4, {} },
-        {103, 5, {} },
-        {103, 6, {} },
-      },
-      RankList = {
-        1,1,1,1,1,1,2,3,4,5,6,7
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Pullover",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {72, 1, {} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {67,1, {} },
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {99, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
 
       },
-    }
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Riot", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,11,2}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,11,3}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {150, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,43,0}} },
+      },
+      RankList = {
+        1,1,2,3,4,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,10,2}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,10,3}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {147, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,51,0}} },
+      },
+      RankList = {
+        1,1,2,3,4,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {94, 0, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {85, 0, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt White", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {94, 2, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {85, 2, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {73, 18, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {224, 1, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Pullover", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {239, 4, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {223, 4, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T4", -- the item will be categorized inside this category
+    CategoryIndex = 4,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {266, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {275, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {311, 13, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {335, 13, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 8, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Belt", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Eagle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {43, 0, {} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {30, 0, {} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 8, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Shoulder", -- the item will be categorized inside this category
+    CategoryIndex = 3,
+    Name = "Chain", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {115, 1, {} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {81, 1, {} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class A",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {19,1,{{10,0,0}} },
+        {19,1,{{10,45,6}} },
+        {19,1,{{10,45,7}} },
+        {19,1,{{10,45,8}} },
+        {19,1,{{10,45,9}} },
+        {19,1,{{10,45,10}} },
+        {19,1,{{10,45,11}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {31,1,{{10,0,0}} },
+        {31,1,{{10,53,6}} },
+        {31,1,{{10,53,7}} },
+        {31,1,{{10,53,8}} },
+        {31,1,{{10,53,9}} },
+        {31,1,{{10,53,10}} },
+        {31,1,{{10,53,11}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B Collar",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {26,1,{{10,0,0}} },
+        {26,1,{{10,44,6}} },
+        {26,1,{{10,44,7}} },
+        {26,1,{{10,44,8}} },
+        {26,1,{{10,44,9}} },
+        {26,1,{{10,44,10}} },
+        {26,1,{{10,43,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {28,1,{{10,0,0}} },
+        {28,1,{{10,52,6}} },
+        {28,1,{{10,52,7}} },
+        {28,1,{{10,52,8}} },
+        {28,1,{{10,52,9}} },
+        {28,1,{{10,52,10}} },
+        {28,1,{{10,51,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {28,1,{{10,0,0}} },
+        {28,1,{{10,44,6}} },
+        {28,1,{{10,44,7}} },
+        {28,1,{{10,44,8}} },
+        {28,1,{{10,44,9}} },
+        {28,1,{{10,44,10}} },
+        {28,1,{{10,43,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {30,1,{{10,0,0}} },
+        {30,1,{{10,52,6}} },
+        {30,1,{{10,52,7}} },
+        {30,1,{{10,52,8}} },
+        {30,1,{{10,52,9}} },
+        {30,1,{{10,52,10}} },
+        {30,1,{{10,51,0}} },
+      }
+    },
   },
 }

--- a/Config/Wardrobes/Files/DPOS/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/DPOS/AccessoiresEUP.lua
@@ -9,27 +9,6 @@ DPOSAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {10,6,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {10,2,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Cap",
-    CategoryIndex = 0,
-    Name = "Cap",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
         {56,4,{} },
       }
     },

--- a/Config/Wardrobes/Files/DPOS/LegsEUP.lua
+++ b/Config/Wardrobes/Files/DPOS/LegsEUP.lua
@@ -9,14 +9,14 @@ DPOSLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {36,0,{{6,51,0}} },
+        {36,0,{{6,25,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {35,0,{{6,52,0}} },
+        {35,0,{{6,25,0}} },
       }
     },
   },
@@ -30,14 +30,14 @@ DPOSLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {53,0,{{6,51,0}} },
+        {53,0,{{6,25,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {55,0,{{6,52,0}} },
+        {55,0,{{6,25,0}} },
       }
     },
   },

--- a/Config/Wardrobes/Files/DPOS/TopsEUP.lua
+++ b/Config/Wardrobes/Files/DPOS/TopsEUP.lua
@@ -37,7 +37,7 @@ DPOSTops = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {54,0,{} },
+        {56,0,{} },
       }
     },
   },
@@ -58,28 +58,7 @@ DPOSTops = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {55,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt",
-    CategoryIndex = 2,
-    Name = "Working Belt",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {90,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {55,1,{} },
+        {54,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/FIRE/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/FIRE/AccessoiresEUP.lua
@@ -63,65 +63,65 @@ FIREAccessoires = {
     },
   },
   {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 0,
-    Name = "Helicopter",
+    Type = 0,
+    ComponentID = 9,
+    Category = "Vest",
+    CategoryIndex = 2,
+    Name = "Medic Equip",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {79,4,{} },
+        {1,2,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {78,4,{} },
+        {1,2,{} },
       }
     },
   },
   {
     Type = 0,
-    ComponentID = 10,
-    Category = "Sticker",
-    CategoryIndex = 0,
-    Name = "Cloth Label",
+    ComponentID = 8,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "EMT Class B",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {57,0,{} },
+        {11,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {65,0,{} },
+        {12,0,{} },
       }
     },
   },
   {
     Type = 0,
-    ComponentID = 10,
-    Category = "Sticker",
-    CategoryIndex = 0,
-    Name = "Cloth Label",
+    ComponentID = 8,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "EMT Class B",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {58,0,{} },
+        {12,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {66,0,{} },
+        {11,0,{} },
       }
     },
   },
@@ -226,7 +226,7 @@ FIREAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {97,0,{} },
+        {87,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/FIRE/LegsEUP.lua
+++ b/Config/Wardrobes/Files/FIRE/LegsEUP.lua
@@ -2,42 +2,21 @@ FIRELegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Uniform",
     CategoryIndex = 2,
-    Name = "Firefighter Pants",
+    Name = "Standard Issue",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {19,0,{{6,51,0}} },
+        {101,0,{{6,97,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {41,3,{{6,52,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 4,
-    Category = "Pants",
-    CategoryIndex = 2,
-    Name = "Firefighter Pants",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,1,{{6,51,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {41,3,{{6,52,0}} },
+        {105,0,{{6,86,0}} },
       }
     },
   },
@@ -46,19 +25,19 @@ FIRELegs = {
     ComponentID = 4,
     Category = "Uniform",
     CategoryIndex = 2,
-    Name = "Firefighter",
+    Name = "Alternative Issue",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {25,3,{{6,51,0}} },
+        {25,3,{{6,97,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {41,3,{{6,52,0}} },
+        {41,3,{{6,86,0}} },
       }
     },
   },
@@ -67,82 +46,19 @@ FIRELegs = {
     ComponentID = 4,
     Category = "Uniform",
     CategoryIndex = 2,
-    Name = "Paramedic",
+    Name = "HI-VIS",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {96,0,{{6,51,0}} },
+        {120,0,{{6,97,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {99,0,{{6,52,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 4,
-    Category = "Uniform",
-    CategoryIndex = 2,
-    Name = "Paramedic",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {96,1,{{6,51,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {99,1,{{6,52,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 4,
-    Category = "Pants + Shoes",
-    CategoryIndex = 4,
-    Name = "Firefighter Pants",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {43,0,{{6,30,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {18,0,{{6,9,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 4,
-    Category = "Pants + Shoes",
-    CategoryIndex = 4,
-    Name = "Firefighter Pants",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {43,1,{{6,30,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {18,1,{{6,9,0}} },
+        {126,0,{{6,86,0}} },
       }
     },
   },

--- a/Config/Wardrobes/Files/FIRE/TopsEUP.lua
+++ b/Config/Wardrobes/Files/FIRE/TopsEUP.lua
@@ -1,6 +1,69 @@
 FIRETops = {
   {
     Type = 0,
+    ComponentID = 11,
+    Category = "Jacket T6",
+    CategoryIndex = 6,
+    Name = "HI-VIS Fire Jacket",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {250,1,{{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {258,1,{{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 11,
+    Category = "Jacket T6",
+    CategoryIndex = 6,
+    Name = "HI-VIS Fire Jacket",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {314,0,{{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {325,0,{{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 11,
+    Category = "Jacket T6",
+    CategoryIndex = 6,
+    Name = "HI-VIS Fire Jacket",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {315,0,{{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {326,0,{{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
     ComponentID = 8,
     Category = "Belt",
     CategoryIndex = 2,
@@ -86,9 +149,30 @@ FIRETops = {
   {
     Type = 0,
     ComponentID = 8,
-    Category = "Equip",
+    Category = "Shoulder",
     CategoryIndex = 3,
-    Name = "Breathing Equipment",
+    Name = "Oxygen Bottle",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {151,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {187,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 8,
+    Category = "Shoulder",
+    CategoryIndex = 3,
+    Name = "Radio",
     Male = {
       Ranked = false,
       RankList = {},
@@ -107,9 +191,9 @@ FIRETops = {
   {
     Type = 0,
     ComponentID = 8,
-    Category = "Equip",
-    CategoryIndex = 5,
-    Name = "Breathing Equipment",
+    Category = "Shoulder",
+    CategoryIndex = 3,
+    Name = "Radio",
     Male = {
       Ranked = false,
       RankList = {},

--- a/Config/Wardrobes/Files/GEN/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/GEN/AccessoiresEUP.lua
@@ -275,27 +275,6 @@ GENAccessoires = {
   {
     Type = 0,
     ComponentID = 7,
-    Category = "Sticker",
-    CategoryIndex = 0,
-    Name = "American Flag",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {13,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {0,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
     Category = "Suspenders",
     CategoryIndex = 0,
     Name = "Red",
@@ -311,69 +290,6 @@ GENAccessoires = {
       RankList = {},
       ClothList = {
         {88,2,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Belt + Chest",
-    CategoryIndex = 2,
-    Name = "Radio and Mic",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {1,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {1,2,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Belt + Chest",
-    CategoryIndex = 2,
-    Name = "Radio and Mic",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {2,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {2,1,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Belt + Chest",
-    CategoryIndex = 2,
-    Name = "Radio and Mic",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {2,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {2,2,{} },
       }
     },
   },
@@ -471,14 +387,14 @@ GENAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {10,4,{} },
+        {3,4,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {5,2,{} },
+        {5,4,{} },
       }
     },
   },
@@ -527,147 +443,84 @@ GENAccessoires = {
   {
     Type = 0,
     ComponentID = 9,
-    Category = "Traffic Vest",
+    Category = "Mic",
     CategoryIndex = 2,
-    Name = "Yellow Wide",
+    Name = "Belt",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {18,4,{} },
+        {29,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {19,4,{} },
+        {33,0,{} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 9,
-    Category = "Traffic Vest",
+    Category = "Mic",
     CategoryIndex = 2,
-    Name = "Yellow Wide",
+    Name = "Over Shoulder",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {18,5,{} },
+        {37,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {19,5,{} },
+        {15,0,{} },
       }
     },
   },
   {
     Type = 0,
-    ComponentID = 9,
-    Category = "Traffic Vest",
-    CategoryIndex = 2,
-    Name = "Yellow Dirty Wide",
+    ComponentID = 5,
+    Category = "Harness",
+    CategoryIndex = 0,
+    Name = "Leg Harness",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {18,6,{} },
+        {9,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {19,6,{} },
+        {9,0,{} },
       }
     },
   },
   {
     Type = 0,
-    ComponentID = 9,
-    Category = "Traffic Vest",
-    CategoryIndex = 2,
-    Name = "Orange Dirty Wide",
+    ComponentID = 5,
+    Category = "Harness",
+    CategoryIndex = 0,
+    Name = "Body Harness",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {18,7,{} },
+        {19,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {19,7,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt Dark Blue",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {28,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {30,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt Beige",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {28,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {30,1,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt Gray",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {28,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {30,2,{} },
+        {19,0,{} },
       }
     },
   },
@@ -794,27 +647,6 @@ GENAccessoires = {
       RankList = {},
       ClothList = {
         {77,0,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 1,
-    Name = "Helicopter",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {79,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {78,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/GEN/LegsEUP.lua
+++ b/Config/Wardrobes/Files/GEN/LegsEUP.lua
@@ -2,7 +2,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Trousers",
     Male = {
@@ -23,7 +23,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Trousers",
     Male = {
@@ -44,7 +44,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Trousers",
     Male = {
@@ -65,7 +65,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Trousers",
     Male = {
@@ -86,7 +86,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Trousers",
     Male = {
@@ -107,7 +107,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Trousers",
     Male = {
@@ -128,7 +128,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Trousers",
     Male = {
@@ -149,7 +149,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Trousers",
     Male = {
@@ -170,7 +170,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Jeans",
     Male = {
@@ -191,7 +191,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Jeans",
     Male = {
@@ -212,7 +212,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Jeans",
     Male = {
@@ -380,7 +380,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Baggy",
     Male = {
@@ -401,7 +401,7 @@ GENLegs = {
   {
     Type = 0,
     ComponentID = 4,
-    Category = "Pants",
+    Category = "Civilian",
     CategoryIndex = 2,
     Name = "Baggy",
     Male = {
@@ -450,6 +450,27 @@ GENLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
+        {97,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {86,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 6,
+    Category = "Uniform",
+    CategoryIndex = 2,
+    Name = "Boots",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
         {12,6,{} },
       }
     },
@@ -471,14 +492,14 @@ GENLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {24,0,{} },
+        {25,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {24,0,{} },
+        {25,0,{} },
       }
     },
   },
@@ -521,6 +542,27 @@ GENLegs = {
       RankList = {},
       ClothList = {
         {29,2,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 6,
+    Category = "Uniform",
+    CategoryIndex = 2,
+    Name = "Shoes",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {10,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {29,0,{} },
       }
     },
   },
@@ -597,14 +639,14 @@ GENLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {30,0,{} },
+        {13,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {9,0,{} },
+        {26,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/GEN/TopsEUP.lua
+++ b/Config/Wardrobes/Files/GEN/TopsEUP.lua
@@ -2,273 +2,168 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Uniform",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Pullover",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {55,0,{{3,0,0},{8,15,0},{9,0,0}} },
+        {139,0,{{3,4,0}, {8,15,0}, {9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {48,0,{{3,14,0},{8,14,0},{9,0,0}} },
+        {136,0,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Pullover",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Brown",
+    Name = "Pullover",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {111,2,{{3,4,0}, {8,15,0}, {9,0,0}} },
+        {139,1,{{3,4,0}, {8,15,0}, {9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {103,2,{{3,3,0},{8,14,0},{9,0,0}} },
+        {136,1,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Pullover",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Black",
+    Name = "Pullover",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {111,3,{{3,4,0}, {8,15,0}, {9,0,0}} },
+        {139,2,{{3,4,0}, {8,15,0}, {9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {103,3,{{3,3,0},{8,14,0},{9,0,0}} },
+        {136,2,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Pullover",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Blue",
+    Name = "Pullover",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {111,4,{{3,4,0}, {8,15,0}, {9,0,0}} },
+        {139,3,{{3,4,0}, {8,15,0}, {9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {103,4,{{3,3,0},{8,14,0},{9,0,0}} },
+        {136,3,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Pullover",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Gray",
+    Name = "Pullover",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {111,5,{{3,4,0}, {8,15,0}, {9,0,0}} },
+        {139,4,{{3,4,0}, {8,15,0}, {9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {103,5,{{3,3,0},{8,14,0},{9,0,0}} },
+        {136,4,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Pullover",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Gray",
+    Name = "Pullover",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {139,0,{{3,4,0}, {8,15,0}, {9,0,0}} },
+        {139,5,{{3,4,0}, {8,15,0}, {9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {136,0,{{3,3,0},{8,14,0},{9,0,0}} },
+        {136,5,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Pullover",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Red",
+    Name = "Pullover",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {139,1,{{3,4,0}, {8,15,0}, {9,0,0}} },
+        {139,6,{{3,4,0}, {8,15,0}, {9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {136,1,{{3,3,0},{8,14,0},{9,0,0}} },
+        {136,6,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Pullover",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Brown",
+    Name = "Pullover",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {139,2,{{3,4,0}, {8,15,0}, {9,0,0}} },
+        {139,7,{{3,4,0}, {8,15,0}, {9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {136,2,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Pullover",
-    CategoryIndex = 0,
-    Name = "Black",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {139,3,{{3,4,0}, {8,15,0}, {9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {136,3,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Pullover",
-    CategoryIndex = 0,
-    Name = "Blue",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {139,4,{{3,4,0}, {8,15,0}, {9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {136,4,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Pullover",
-    CategoryIndex = 0,
-    Name = "White",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {139,5,{{3,4,0}, {8,15,0}, {9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {136,5,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Pullover",
-    CategoryIndex = 0,
-    Name = "Purple",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {139,6,{{3,4,0}, {8,15,0}, {9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {136,6,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Pullover",
-    CategoryIndex = 0,
-    Name = "Green",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {139,7,{{3,4,0}, {8,15,0}, {9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {136,7,{{3,3,0},{8,14,0},{9,0,0}} },
+        {136,7,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
@@ -276,9 +171,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Black",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -297,9 +192,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "White",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -318,9 +213,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Blue",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -339,9 +234,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Green",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -360,9 +255,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Blue",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -381,9 +276,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Blue",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -402,9 +297,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Blue",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -423,9 +318,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Yellow",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -444,9 +339,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Red",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -465,9 +360,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "White",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -486,9 +381,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Green",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -507,9 +402,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Red",
+    Name = "Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -528,9 +423,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "T-Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Gray",
+    Name = "T-Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -549,9 +444,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "T-Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Blue",
+    Name = "T-Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -570,9 +465,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "T-Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "White",
+    Name = "T-Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -591,9 +486,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "T-Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Yellow",
+    Name = "T-Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -612,9 +507,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "T-Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Black",
+    Name = "T-Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -633,9 +528,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "T-Shirt",
+    Category = "Civilian 0",
     CategoryIndex = 0,
-    Name = "Red",
+    Name = "T-Shirt",
     Male = {
       Ranked = false,
       RankList = {},
@@ -654,9 +549,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -675,9 +570,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -696,9 +591,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -717,9 +612,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -738,9 +633,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -759,9 +654,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -780,9 +675,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -801,9 +696,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -822,9 +717,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -843,9 +738,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Jacket T5",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Civilian",
+    Name = "Jacket",
     Male = {
       Ranked = false,
       RankList = {},
@@ -864,9 +759,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Suit",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Black",
+    Name = "Suit",
     Male = {
       Ranked = false,
       RankList = {},
@@ -885,9 +780,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Suit",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "White",
+    Name = "Suit",
     Male = {
       Ranked = false,
       RankList = {},
@@ -906,9 +801,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Suit",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "White",
+    Name = "Suit",
     Male = {
       Ranked = false,
       RankList = {},
@@ -927,9 +822,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Suit",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Gray",
+    Name = "Suit",
     Male = {
       Ranked = false,
       RankList = {},
@@ -948,9 +843,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Suit",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Blue",
+    Name = "Suit",
     Male = {
       Ranked = false,
       RankList = {},
@@ -969,9 +864,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Suit",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Red",
+    Name = "Suit",
     Male = {
       Ranked = false,
       RankList = {},
@@ -990,9 +885,9 @@ GENTops = {
   {
     Type = 0,
     ComponentID = 11,
-    Category = "Suit",
+    Category = "Civilian 5",
     CategoryIndex = 5,
-    Name = "Green",
+    Name = "Suit",
     Male = {
       Ranked = false,
       RankList = {},
@@ -1089,174 +984,6 @@ GENTops = {
       RankList = {},
       ClothList = {
         {14,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {65,16,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {45,16,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {65,17,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {45,17,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt + Tie",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {66,16,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {45,16,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt + Tie",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {66,17,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {45,17,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Pullover",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {72,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {67,2,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Pullover",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {72,3,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {67,3,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Pullover",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {72,4,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {67,4,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Pullover",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {72,5,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {67,5,{} },
       }
     },
   },
@@ -1950,27 +1677,6 @@ GENTops = {
       RankList = {},
       ClothList = {
         {6,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt",
-    CategoryIndex = 2,
-    Name = "Radio",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {87,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {65,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/LSFD/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/LSFD/AccessoiresEUP.lua
@@ -9,35 +9,14 @@ LSFDAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {9,5,{} },
+        {10,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {43,2,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Cap",
-    CategoryIndex = 0,
-    Name = "Cap",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {44,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {43,2,{} },
+        {10,0,{} },
       }
     },
   },
@@ -84,6 +63,75 @@ LSFDAccessoires = {
       RankList = {},
       ClothList = {
         {15,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 10,
+    Category = "Sticker",
+    CategoryIndex = 0,
+    Name = "Cloth Label",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {57,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {65,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 10,
+    Category = "Sticker",
+    CategoryIndex = 0,
+    Name = "Cloth Label",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {64,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {73,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 5,
+    Category = "Badge",
+    CategoryIndex = 0,
+    Name = "Badge",
+    Male = {
+      Ranked = true,
+      RankList = {1,2,2,1,3,3,3,4,4},
+      ClothList = {
+        {57,6,{} },
+        {57,5,{} },
+        {57,7,{} },
+        {57,8,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,2,2,1,3,3,3,4,4},
+      ClothList = {
+        {57,6,{} },
+        {57,5,{} },
+        {57,7,{} },
+        {57,8,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/LSFD/TopsEUP.lua
+++ b/Config/Wardrobes/Files/LSFD/TopsEUP.lua
@@ -1,148 +1,217 @@
 LSFDTops = {
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Class C", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {47,0,{{3,0,0},{8,15,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {74, 7, {{3,11,0},{5,57,6},{8,15,0},{9,0,0},{10,0,0}} },
+        {74, 0, {{3,11,0},{5,57,5},{8,15,0},{9,0,0},{10,0,0}} },
+        {74, 7, {{3,11,0},{5,57,7},{8,15,0},{9,0,0},{10,0,0}} },
+        {74, 7, {{3,11,0},{5,57,8},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,2,{{3,14,0},{8,14,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {25, 7, {{3,9,0},{5,57,6},{8,14,0},{9,0,0},{10,0,0}} },
+        {25, 0, {{3,9,0},{5,57,5},{8,14,0},{9,0,0},{10,0,0}} },
+        {25, 7, {{3,9,0},{5,57,7},{8,14,0},{9,0,0},{10,0,0}} },
+        {25, 7, {{3,9,0},{5,57,8},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {47,1,{{3,0,0},{8,15,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {75, 1, {{3,4,0},{5,57,6},{8,15,0},{9,0,0},{10,0,0}} },
+        {75, 0, {{3,4,0},{5,57,5},{8,15,0},{9,0,0},{10,0,0}} },
+        {75, 1, {{3,4,0},{5,57,7},{8,15,0},{9,0,0},{10,0,0}} },
+        {75, 1, {{3,4,0},{5,57,8},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,3,{{3,14,0},{8,14,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {26, 1, {{3,3,0},{5,57,6},{8,14,0},{9,0,0},{10,0,0}} },
+        {26, 0, {{3,3,0},{5,57,5},{8,14,0},{9,0,0},{10,0,0}} },
+        {26, 1, {{3,3,0},{5,57,7},{8,14,0},{9,0,0},{10,0,0}} },
+        {26, 1, {{3,3,0},{5,57,8},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T4",
-    CategoryIndex = 4,
-    Name = "Hi Vis",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {71,0,{{3,4,0},{8,15,0},{9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {67,0,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T6",
-    CategoryIndex = 6,
-    Name = "Firefighter",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {77,0,{{3,4,0},{8,15,0},{9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {64,0,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T6",
-    CategoryIndex = 6,
-    Name = "Firefighter",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {77,1,{{3,4,0},{8,15,0},{9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {64,1,{{3,3,0},{8,14,0},{9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Class A", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {250,0,{{3,0,0},{8,15,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {118, 0, {{3,4,0},{5,57,6},{8,15,0},{9,0,0},{10,0,0}} },
+        {118, 1, {{3,4,0},{5,57,5},{8,15,0},{9,0,0},{10,0,0}} },
+        {118, 0, {{3,4,0},{5,57,7},{8,15,0},{9,0,0},{10,0,0}} },
+        {118, 0, {{3,4,0},{5,57,8},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {258,0,{{3,14,0},{8,14,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {18, 0, {{3,3,0},{5,57,6},{8,14,0},{9,0,0},{10,0,0}} },
+        {18, 1, {{3,3,0},{5,57,5},{8,14,0},{9,0,0},{10,0,0}} },
+        {18, 0, {{3,3,0},{5,57,7},{8,14,0},{9,0,0},{10,0,0}} },
+        {18, 0, {{3,3,0},{5,57,8},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,3,3,3,4,4
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {73, 14, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {224, 21, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Pullover", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {239, 11, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {239, 12, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,1,1,1,1,1
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {223, 11, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {223, 12, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+        1,2,2,1,1,1,1,1,1
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Eagle", -- the item will be categorized inside this category
+    CategoryIndex = 3,
+    Name = "Eagle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {108, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {99, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Paramedic", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {151, 2, {{3,4,0},{5,0,0},{8,15,0},{9,28,3},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {148, 2, {{3,3,0},{5,0,0},{8,14,0},{9,30,3},{10,0,0}} },
+      },
+      RankList = {
+
+      },
     },
   },
   {
     Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
-    CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {250,1,{{3,0,0},{8,15,0},{9,0,0}} },
+        {28,3,{{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {258,1,{{3,14,0},{8,14,0},{9,0,0}} },
+        {30,3,{{10,0,0}} },
       }
     },
   },

--- a/Config/Wardrobes/Files/LSPD/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/LSPD/AccessoiresEUP.lua
@@ -1,6 +1,43 @@
 LSPDAccessoires = {
   {
     Type = 0,
+    ComponentID = 5,
+    Category = "Badges",
+    CategoryIndex = 0,
+    Name = "Badge",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,2,2,3,3,4,5,6,7,8,9},
+      ClothList = {
+        {52,0,{} },
+        {52,4,{} },
+        {52,1,{} },
+        {52,2,{} },
+        {52,3,{} },
+        {52,5,{} },
+        {52,6,{} },
+        {52,7,{} },
+        {52,8,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,2,2,3,3,4,5,6,7,8,9},
+      ClothList = {
+        {52,0,{} },
+        {52,4,{} },
+        {52,1,{} },
+        {52,2,{} },
+        {52,3,{} },
+        {52,5,{} },
+        {52,6,{} },
+        {52,7,{} },
+        {52,8,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
     ComponentID = 9,
     Category = "Traffic Vest",
     CategoryIndex = 2,
@@ -17,69 +54,6 @@ LSPDAccessoires = {
       RankList = {},
       ClothList = {
         {19,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Traffic Vest",
-    CategoryIndex = 2,
-    Name = "LSPD Wide",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {18,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Belt",
-    CategoryIndex = 3,
-    Name = "Radio, Pass and Clip",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {0,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Chain",
-    CategoryIndex = 2,
-    Name = "Detective Badge",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {20,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {23,1,{} },
       }
     },
   },
@@ -112,9 +86,11 @@ LSPDAccessoires = {
     Name = "Badge + Handcuffs",
     Male = {
       Ranked = true,
-      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
+      RankList = {1,1,1,1,2,2,2,3,3,4,5,6,7,8,9},
       ClothList = {
+        {24,3,{} },
         {24,0,{} },
+        {24,1,{} },
         {24,4,{} },
         {24,5,{} },
         {24,6,{} },
@@ -125,9 +101,11 @@ LSPDAccessoires = {
     },
     Female = {
       Ranked = true,
-      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
+      RankList = {1,1,1,1,2,2,2,3,3,4,5,6,7,8,9},
       ClothList = {
+        {26,3,{} },
         {26,0,{} },
+        {26,1,{} },
         {26,4,{} },
         {26,5,{} },
         {26,6,{} },
@@ -138,93 +116,24 @@ LSPDAccessoires = {
     },
   },
   {
-    Type = 0,
-    ComponentID = 10,
-    Category = "Rank Insignia",
-    CategoryIndex = 1,
-    Name = "Side, higher Position",
-    Male = {
-      Ranked = true,
-      RankList = {1,1,2,3,5,6,7,8,4,1,1,1,1,1,1},
-      ClothList = {
-        {0,0,{} },
-        {8,0,{} },
-        {11,0,{} },
-        {11,1,{} },
-        {11,2,{} },
-        {11,3,{} },
-        {11,4,{} },
-        {8,1,{} },
-      }
-    },
-    Female = {
-      Ranked = true,
-      RankList = {1,1,2,3,5,6,7,8,4,1,1,1,1,1,1},
-      ClothList = {
-        {0,0,{} },
-        {7,0,{} },
-        {10,0,{} },
-        {10,1,{} },
-        {10,2,{} },
-        {10,3,{} },
-        {10,4,{} },
-        {7,1,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 10,
-    Category = "Rank Insignia",
-    CategoryIndex = 1,
-    Name = "Side, lower Position",
-    Male = {
-      Ranked = true,
-      RankList = {1,1,2,3,6,7,8,4,5,1,1,1,1,1,1},
-      ClothList = {
-        {0,0,{} },
-        {12,0,{} },
-        {12,1,{} },
-        {12,2,{} },
-        {12,3,{} },
-        {12,4,{} },
-        {12,5,{} },
-        {12,6,{} },
-        {12,7,{} },
-      }
-    },
-    Female = {
-      Ranked = true,
-      RankList = {1,1,2,3,5,6,7,8,4,1,1,1,1,1,1},
-      ClothList = {
-        {0,0,{} },
-        {7,0,{} },
-        {10,0,{} },
-        {10,1,{} },
-        {10,2,{} },
-        {10,3,{} },
-        {10,4,{} },
-        {7,1,{} },
-      }
-    },
-  },
-  {
     Type = 1,
     ComponentID = 0,
     Category = "Cap",
     CategoryIndex = 0,
     Name = "Duty Cap",
     Male = {
-      Ranked = false,
-      RankList = {},
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,1,1,1,2,2,2,2,2,2},
       ClothList = {
+        {46,0,{} },
         {1,0,{} },
       }
     },
     Female = {
-      Ranked = false,
-      RankList = {},
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,1,1,1,2,2,2,2,2,2},
       ClothList = {
+        {45,0,{} },
         {1,0,{} },
       }
     },
@@ -253,27 +162,6 @@ LSPDAccessoires = {
   {
     Type = 1,
     ComponentID = 0,
-    Category = "Cap",
-    CategoryIndex = 0,
-    Name = "Duty Cap",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {46,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {45,0,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
     Category = "Helmet",
     CategoryIndex = 0,
     Name = "Helicopter",
@@ -295,21 +183,204 @@ LSPDAccessoires = {
   {
     Type = 1,
     ComponentID = 0,
-    Category = "Helmet",
+    Category = "Cap",
     CategoryIndex = 0,
-    Name = "Helicopter",
+    Name = "Cap",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {79,1,{} },
+        {135,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {78,1,{} },
+        {134,0,{} },
+      }
+    },
+  },
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Cap",
+    CategoryIndex = 0,
+    Name = "Cap",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {135,1,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {134,1,{} },
+      }
+    },
+  },
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Cap",
+    CategoryIndex = 0,
+    Name = "Cap",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {135,2,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {134,2,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 10,
+    Category = "Rank Insignia",
+    CategoryIndex = 0,
+    Name = "Rank Insignia Class C",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9,10,11,12,13,14},
+      ClothList = {
+        {0,0,{} },
+        {15,0,{} },
+        {15,1,{} },
+        {15,2,{} },
+        {15,3,{} },
+        {15,4,{} },
+        {15,5,{} },
+        {15,6,{} },
+        {44,0,{} },
+        {44,1,{} },
+        {44,2,{} },
+        {44,3,{} },
+        {44,4,{} },
+        {44,5,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,1,1,1,1,1,1},
+      ClothList = {
+        {0,0,{} },
+        {14,0,{} },
+        {14,1,{} },
+        {14,2,{} },
+        {14,3,{} },
+        {14,4,{} },
+        {14,5,{} },
+        {14,6,{} },
+        {52,0,{} },
+        {52,1,{} },
+        {52,2,{} },
+        {52,3,{} },
+        {52,4,{} },
+        {52,5,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 10,
+    Category = "Rank Insignia",
+    CategoryIndex = 0,
+    Name = "Rank Insignia Class B",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9,10,11,12,13,14},
+      ClothList = {
+        {0,0,{} },
+        {12,0,{} },
+        {12,1,{} },
+        {12,2,{} },
+        {12,3,{} },
+        {12,4,{} },
+        {12,5,{} },
+        {12,6,{} },
+        {44,0,{} },
+        {44,1,{} },
+        {44,2,{} },
+        {44,3,{} },
+        {44,4,{} },
+        {44,5,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9,10,11,12,13,14},
+      ClothList = {
+        {0,0,{} },
+        {11,0,{} },
+        {11,1,{} },
+        {11,2,{} },
+        {11,3,{} },
+        {11,4,{} },
+        {11,5,{} },
+        {11,6,{} },
+        {52,0,{} },
+        {52,1,{} },
+        {52,2,{} },
+        {52,3,{} },
+        {52,4,{} },
+        {52,5,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 10,
+    Category = "Rank Insignia",
+    CategoryIndex = 0,
+    Name = "Rank Insignia Class A",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9,10,11,12,13,14},
+      ClothList = {
+        {0,0,{} },
+        {12,0,{} },
+        {12,1,{} },
+        {12,2,{} },
+        {12,3,{} },
+        {12,4,{} },
+        {12,5,{} },
+        {12,6,{} },
+        {45,0,{} },
+        {45,1,{} },
+        {45,2,{} },
+        {45,3,{} },
+        {45,4,{} },
+        {45,5,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9,10,11,12,13,14},
+      ClothList = {
+        {0,0,{} },
+        {11,0,{} },
+        {11,1,{} },
+        {11,2,{} },
+        {11,3,{} },
+        {11,4,{} },
+        {11,5,{} },
+        {11,6,{} },
+        {53,0,{} },
+        {53,1,{} },
+        {53,2,{} },
+        {53,3,{} },
+        {53,4,{} },
+        {53,5,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/LSPD/LegsEUP.lua
+++ b/Config/Wardrobes/Files/LSPD/LegsEUP.lua
@@ -9,14 +9,35 @@ LSPDLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {35,0,{{6,51,0}} },
+        {35,0,{{6,25,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {34,0,{{6,52,0}} },
+        {34,0,{{6,25,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Eagle",
+    CategoryIndex = 2,
+    Name = "Standard Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {64,0,{{6,25,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {66,0,{{6,25,0}} },
       }
     },
   },
@@ -30,14 +51,35 @@ LSPDLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {32,1,{{6,30,0}} },
+        {32,1,{{6,13,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {31,1,{{6,9,0}} },
+        {31,1,{{6,26,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Combat Uniform",
+    CategoryIndex = 3,
+    Name = "Standard Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {125,6,{{6,51,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {131,6,{{6,101,0}} },
       }
     },
   },

--- a/Config/Wardrobes/Files/LSPD/TopsEUP.lua
+++ b/Config/Wardrobes/Files/LSPD/TopsEUP.lua
@@ -4,430 +4,967 @@ LSPDTops = {
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
     Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Class C", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
       Ranked = true, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {149, 0, {{3,0,0},{8,15,0},{9,0,0}} },
-        {149, 9, {{3,0,0},{8,15,0},{9,0,0}} },
-        {149, 1, {{3,0,0},{8,15,0},{9,0,0}} },
-        {149, 2, {{3,0,0},{8,15,0},{9,0,0}} },
-        {149, 3, {{3,0,0},{8,15,0},{9,0,0}} },
-        {149, 4, {{3,0,0},{8,15,0},{9,0,0}} },
-        {149, 5, {{3,0,0},{8,15,0},{9,0,0}} },
-        {149, 6, {{3,0,0},{8,15,0},{9,0,0}} },
-        {149, 7, {{3,0,0},{8,15,0},{9,0,0}} },
+        {190, 0, {{3,11,0},{5,52,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {190, 0, {{3,11,0},{5,52,0},{8,15,0},{9,0,0},{10,15,0}} },
+        {190, 0, {{3,11,0},{5,52,0},{8,15,0},{9,0,0},{10,15,1}} },
+        {190, 0, {{3,11,0},{5,52,4},{8,15,0},{9,0,0},{10,15,4}} },
+        {190, 0, {{3,11,0},{5,52,4},{8,15,0},{9,0,0},{10,15,5}} },
+        {190, 0, {{3,11,0},{5,52,4},{8,15,0},{9,0,0},{10,15,6}} },
+        {190, 0, {{3,11,0},{5,52,1},{8,15,0},{9,0,0},{10,15,2}} },
+        {190, 0, {{3,11,0},{5,52,1},{8,15,0},{9,0,0},{10,15,3}} },
+        {190, 0, {{3,11,0},{5,52,2},{8,15,0},{9,0,0},{10,44,0}} },
+        {190, 0, {{3,11,0},{5,52,3},{8,15,0},{9,0,0},{10,44,1}} },
+        {190, 0, {{3,11,0},{5,52,5},{8,15,0},{9,0,0},{10,44,2}} },
+        {190, 0, {{3,11,0},{5,52,6},{8,15,0},{9,0,0},{10,44,3}} },
+        {190, 0, {{3,11,0},{5,52,7},{8,15,0},{9,0,0},{10,44,4}} },
+        {190, 0, {{3,11,0},{5,52,8},{8,15,0},{9,0,0},{10,44,5}} },
       },
       RankList = {
-        1,1,1,1,2,2,2,3,3,4,5,6,7,8,9
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
       },
     },
     Female = {
       Ranked = true, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {146, 0, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 9, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 1, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 2, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 3, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 4, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 5, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 6, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 7, {{3,14,0},{8,14,0},{9,0,0}} },
+        {192, 0, {{3,9,0},{5,52,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {192, 0, {{3,9,0},{5,52,0},{8,14,0},{9,0,0},{10,14,0}} },
+        {192, 0, {{3,9,0},{5,52,0},{8,14,0},{9,0,0},{10,14,1}} },
+        {192, 0, {{3,9,0},{5,52,4},{8,14,0},{9,0,0},{10,14,4}} },
+        {192, 0, {{3,9,0},{5,52,4},{8,14,0},{9,0,0},{10,14,5}} },
+        {192, 0, {{3,9,0},{5,52,4},{8,14,0},{9,0,0},{10,14,6}} },
+        {192, 0, {{3,9,0},{5,52,1},{8,14,0},{9,0,0},{10,14,2}} },
+        {192, 0, {{3,9,0},{5,52,1},{8,14,0},{9,0,0},{10,14,3}} },
+        {192, 0, {{3,9,0},{5,52,2},{8,14,0},{9,0,0},{10,52,0}} },
+        {192, 0, {{3,9,0},{5,52,3},{8,14,0},{9,0,0},{10,52,1}} },
+        {192, 0, {{3,9,0},{5,52,5},{8,14,0},{9,0,0},{10,52,2}} },
+        {192, 0, {{3,9,0},{5,52,6},{8,14,0},{9,0,0},{10,52,3}} },
+        {192, 0, {{3,9,0},{5,52,7},{8,14,0},{9,0,0},{10,52,4}} },
+        {192, 0, {{3,9,0},{5,52,8},{8,14,0},{9,0,0},{10,52,5}} },
       },
       RankList = {
-        1,1,1,1,2,2,2,3,3,4,5,6,7,8,9
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
       },
     },
 
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve K-9",
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      ClothList = {
-        {102, 0, {{3,0,0},{8,15,0},{9,0,0}} },
-        {102, 3, {{3,0,0},{8,15,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {193, 0, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {193, 0, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,12,0}} },
+        {193, 0, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,12,1}} },
+        {193, 0, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,4}} },
+        {193, 0, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,5}} },
+        {193, 0, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,6}} },
+        {193, 0, {{3,4,0},{5,52,1},{8,15,0},{9,0,0},{10,12,2}} },
+        {193, 0, {{3,4,0},{5,52,1},{8,15,0},{9,0,0},{10,12,3}} },
+        {193, 0, {{3,4,0},{5,52,2},{8,15,0},{9,0,0},{10,44,0}} },
+        {193, 0, {{3,4,0},{5,52,3},{8,15,0},{9,0,0},{10,44,1}} },
+        {193, 0, {{3,4,0},{5,52,5},{8,15,0},{9,0,0},{10,44,2}} },
+        {193, 0, {{3,4,0},{5,52,6},{8,15,0},{9,0,0},{10,44,3}} },
+        {193, 0, {{3,4,0},{5,52,7},{8,15,0},{9,0,0},{10,44,4}} },
+        {193, 0, {{3,4,0},{5,52,8},{8,15,0},{9,0,0},{10,44,5}} },
       },
       RankList = {
-        1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
       },
-    },
-    Female = {
-      Ranked = true,
-      ClothList = {
-        {93, 0, {{3,0,0},{8,15,0},{9,0,0}} },
-        {93, 3, {{3,0,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {
-        1,1,1,1,1,1,1,1,1,2,2,2,2,2,2,
-      },
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
-    CategoryIndex = 0,
-    Name = "Long Sleeve",
-    Male = {
-      Ranked = true,
-      RankList = {1,1,1,1,2,2,2,3,3,4,5,6,7,8,9},
-      ClothList = {
-        {143,0,{{3,4,0}, {8,15,0}, {9,0,0}} },
-        {143,9,{{3,4,0}, {8,15,0}, {9,0,0}} },
-        {143,1,{{3,4,0}, {8,15,0}, {9,0,0}} },
-        {143,2,{{3,4,0}, {8,15,0}, {9,0,0}} },
-        {143,3,{{3,4,0}, {8,15,0}, {9,0,0}} },
-        {143,4,{{3,4,0}, {8,15,0}, {9,0,0}} },
-        {143,5,{{3,4,0}, {8,15,0}, {9,0,0}} },
-        {143,6,{{3,4,0}, {8,15,0}, {9,0,0}} },
-        {143,7,{{3,4,0}, {8,15,0}, {9,0,0}} },
-      }
     },
     Female = {
       Ranked = true, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {146, 0, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 9, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 1, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 2, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 3, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 4, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 5, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 6, {{3,14,0},{8,14,0},{9,0,0}} },
-        {146, 7, {{3,14,0},{8,14,0},{9,0,0}} },
+        {195, 0, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {195, 0, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,11,0}} },
+        {195, 0, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,11,1}} },
+        {195, 0, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,4}} },
+        {195, 0, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,5}} },
+        {195, 0, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,6}} },
+        {195, 0, {{3,3,0},{5,52,1},{8,14,0},{9,0,0},{10,11,2}} },
+        {195, 0, {{3,3,0},{5,52,1},{8,14,0},{9,0,0},{10,11,3}} },
+        {195, 0, {{3,3,0},{5,52,2},{8,14,0},{9,0,0},{10,52,0}} },
+        {195, 0, {{3,3,0},{5,52,3},{8,14,0},{9,0,0},{10,52,1}} },
+        {195, 0, {{3,3,0},{5,52,5},{8,14,0},{9,0,0},{10,52,2}} },
+        {195, 0, {{3,3,0},{5,52,6},{8,14,0},{9,0,0},{10,52,3}} },
+        {195, 0, {{3,3,0},{5,52,7},{8,14,0},{9,0,0},{10,52,4}} },
+        {195, 0, {{3,3,0},{5,52,8},{8,14,0},{9,0,0},{10,52,5}} },
       },
       RankList = {
-        1,1,1,1,2,2,2,3,3,4,5,6,7,8,9
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
       },
     },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Pullover",
-    CategoryIndex = 0,
-    Name = "Black",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {111,0,{{3,4,0}, {8,15,0}, {9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {103,0,{{3,3,0}, {8,14,0}, {9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "T-Shirt",
-    CategoryIndex = 0,
-    Name = "Standard",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {93,0,{{3,0,0}, {8,15,0}, {9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {84,0,{{3,14,0}, {8,14,0}, {9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "T-Shirt",
-    CategoryIndex = 0,
-    Name = "Bicycle Unit",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {93,2,{{3,0,0}, {8,15,0}, {9,0,0}} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {84,2,{{3,14,0}, {8,14,0}, {9,0,0}} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Blue",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {35, 1, {{3,4,0},{8,72,0},{9,0,0}} }
-      },
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {172,0, {{3,3,0},{8,67,0},{9,0,0}} },
-      },
-      RankList = {
 
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class A", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {200, 0, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {200, 0, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,12,0}} },
+        {200, 0, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,12,1}} },
+        {200, 0, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,4}} },
+        {200, 0, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,5}} },
+        {200, 0, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,6}} },
+        {200, 0, {{3,4,0},{5,52,1},{8,15,0},{9,0,0},{10,12,2}} },
+        {200, 0, {{3,4,0},{5,52,1},{8,15,0},{9,0,0},{10,12,3}} },
+        {200, 0, {{3,4,0},{5,52,2},{8,15,0},{9,0,0},{10,45,0}} },
+        {200, 0, {{3,4,0},{5,52,3},{8,15,0},{9,0,0},{10,45,1}} },
+        {200, 0, {{3,4,0},{5,52,5},{8,15,0},{9,0,0},{10,45,2}} },
+        {200, 0, {{3,4,0},{5,52,6},{8,15,0},{9,0,0},{10,45,3}} },
+        {200, 0, {{3,4,0},{5,52,7},{8,15,0},{9,0,0},{10,45,4}} },
+        {200, 0, {{3,4,0},{5,52,8},{8,15,0},{9,0,0},{10,45,5}} },
       },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Blue",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {36,1,{{3,4,0}, {8,72,0},{9,0,0}} },
-      }
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {172,1, {{3,3,0},{8,67,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {202, 0, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {202, 0, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,11,0}} },
+        {202, 0, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,11,1}} },
+        {202, 0, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,4}} },
+        {202, 0, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,5}} },
+        {202, 0, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,6}} },
+        {202, 0, {{3,3,0},{5,52,1},{8,14,0},{9,0,0},{10,11,2}} },
+        {202, 0, {{3,3,0},{5,52,1},{8,14,0},{9,0,0},{10,11,3}} },
+        {202, 0, {{3,3,0},{5,52,2},{8,14,0},{9,0,0},{10,53,0}} },
+        {202, 0, {{3,3,0},{5,52,3},{8,14,0},{9,0,0},{10,53,1}} },
+        {202, 0, {{3,3,0},{5,52,5},{8,14,0},{9,0,0},{10,53,2}} },
+        {202, 0, {{3,3,0},{5,52,6},{8,14,0},{9,0,0},{10,53,3}} },
+        {202, 0, {{3,3,0},{5,52,7},{8,14,0},{9,0,0},{10,53,4}} },
+        {202, 0, {{3,3,0},{5,52,8},{8,14,0},{9,0,0},{10,53,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Black",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B Collar", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {39,0,{{3,4,0}, {8,72,0}, {9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {196, 1, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {196, 1, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,12,0}} },
+        {196, 1, {{3,4,0},{5,52,0},{8,15,0},{9,0,0},{10,12,1}} },
+        {196, 1, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,4}} },
+        {196, 1, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,5}} },
+        {196, 1, {{3,4,0},{5,52,4},{8,15,0},{9,0,0},{10,12,6}} },
+        {196, 1, {{3,4,0},{5,52,1},{8,15,0},{9,0,0},{10,12,2}} },
+        {196, 1, {{3,4,0},{5,52,1},{8,15,0},{9,0,0},{10,12,3}} },
+        {196, 1, {{3,4,0},{5,52,2},{8,15,0},{9,0,0},{10,44,0}} },
+        {196, 1, {{3,4,0},{5,52,3},{8,15,0},{9,0,0},{10,44,1}} },
+        {196, 1, {{3,4,0},{5,52,5},{8,15,0},{9,0,0},{10,44,2}} },
+        {196, 1, {{3,4,0},{5,52,6},{8,15,0},{9,0,0},{10,44,3}} },
+        {196, 1, {{3,4,0},{5,52,7},{8,15,0},{9,0,0},{10,44,4}} },
+        {196, 1, {{3,4,0},{5,52,8},{8,15,0},{9,0,0},{10,44,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {172,0, {{3,3,0},{8,67,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {198, 1, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {198, 1, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,11,0}} },
+        {198, 1, {{3,3,0},{5,52,0},{8,14,0},{9,0,0},{10,11,1}} },
+        {198, 1, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,4}} },
+        {198, 1, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,5}} },
+        {198, 1, {{3,3,0},{5,52,4},{8,14,0},{9,0,0},{10,11,6}} },
+        {198, 1, {{3,3,0},{5,52,1},{8,14,0},{9,0,0},{10,11,2}} },
+        {198, 1, {{3,3,0},{5,52,1},{8,14,0},{9,0,0},{10,11,3}} },
+        {198, 1, {{3,3,0},{5,52,2},{8,14,0},{9,0,0},{10,52,0}} },
+        {198, 1, {{3,3,0},{5,52,3},{8,14,0},{9,0,0},{10,52,1}} },
+        {198, 1, {{3,3,0},{5,52,5},{8,14,0},{9,0,0},{10,52,2}} },
+        {198, 1, {{3,3,0},{5,52,6},{8,14,0},{9,0,0},{10,52,3}} },
+        {198, 1, {{3,3,0},{5,52,7},{8,14,0},{9,0,0},{10,52,4}} },
+        {198, 1, {{3,3,0},{5,52,8},{8,14,0},{9,0,0},{10,52,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Black",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {39,1,{{3,4,0}, {8,72,0}, {9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {29, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {29, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {29, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {29, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {29, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {29, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {29, 6, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {29, 7, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {29, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,0}} },
+        {29, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,1}} },
+        {29, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,2}} },
+        {29, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,3}} },
+        {29, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,4}} },
+        {29, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
     },
     Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {172,1, {{3,3,0},{8,67,0},{9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {200, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {200, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {200, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {200, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {200, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {200, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {200, 6, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {200, 7, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {200, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,0}} },
+        {200, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,1}} },
+        {200, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,2}} },
+        {200, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,3}} },
+        {200, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,4}} },
+        {200, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T5",
-    CategoryIndex = 5,
-    Name = "Blue",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      RankList = {1,1,1,2,6,7,8,4,5,1,1,1,1,1,1},
-      ClothList = {
-        {154,0,{{3,4,0}, {8,72,0}, {9,0,0}} },
-        {154,1,{{3,4,0}, {8,72,0}, {9,0,0}} },
-        {154,2,{{3,4,0}, {8,72,0}, {9,0,0}} },
-        {154,3,{{3,4,0}, {8,72,0}, {9,0,0}} },
-        {154,4,{{3,4,0}, {8,72,0}, {9,0,0}} },
-        {154,5,{{3,4,0}, {8,72,0}, {9,0,0}} },
-        {154,6,{{3,4,0}, {8,72,0}, {9,0,0}} },
-        {154,7,{{3,4,0}, {8,72,0}, {9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {187, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {187, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,0}} },
+        {187, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,1}} },
+        {187, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,2}} },
+        {187, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,3}} },
+        {187, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,4}} },
+        {187, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,5}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,1,1,1,2,3,4,5,6,7
+      },
     },
     Female = {
-      Ranked = true,
-      RankList = {1,1,1,2,6,7,8,4,5,1,1,1,1,1,1},
-      ClothList = {
-        {151,0,{{3,3,0}, {8,67,0}, {9,0,0}} },
-        {151,1,{{3,3,0}, {8,67,0}, {9,0,0}} },
-        {151,2,{{3,3,0}, {8,67,0}, {9,0,0}} },
-        {151,3,{{3,3,0}, {8,67,0}, {9,0,0}} },
-        {151,4,{{3,3,0}, {8,67,0}, {9,0,0}} },
-        {151,5,{{3,3,0}, {8,67,0}, {9,0,0}} },
-        {151,6,{{3,3,0}, {8,67,0}, {9,0,0}} },
-        {151,7,{{3,3,0}, {8,67,0}, {9,0,0}} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {189, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {189, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,0}} },
+        {189, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,1}} },
+        {189, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,2}} },
+        {189, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,3}} },
+        {189, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,4}} },
+        {189, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,5}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,1,1,1,2,3,4,5,6,7
+      },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
-      ClothList = {
-        {51,0,{} },
-        {51,1,{} },
-        {51,2,{} },
-        {51,3,{} },
-        {51,4,{} },
-        {51,5,{} },
-        {51,6,{} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {35, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {35, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,0}} },
+        {35, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,1}} },
+        {35, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,2}} },
+        {35, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,3}} },
+        {35, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,4}} },
+        {35, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,5}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,1,1,1,2,3,4,5,6,7
+      },
     },
     Female = {
-      Ranked = true,
-      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
-      ClothList = {
-        {53,0,{} },
-        {53,1,{} },
-        {53,2,{} },
-        {53,3,{} },
-        {53,4,{} },
-        {53,5,{} },
-        {53,6,{} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {168, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {168, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,0}} },
+        {168, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,1}} },
+        {168, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,2}} },
+        {168, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,3}} },
+        {168, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,4}} },
+        {168, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,5}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,1,1,1,2,3,4,5,6,7
+      },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt + Tie",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Winter", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
-      ClothList = {
-        {52,0,{} },
-        {52,1,{} },
-        {52,2,{} },
-        {52,3,{} },
-        {52,4,{} },
-        {52,5,{} },
-        {52,6,{} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {154, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {154, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,0,0}} },
+        {154, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,0}} },
+        {154, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,1}} },
+        {154, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,2}} },
+        {154, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,3}} },
+        {154, 6, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,4}} },
+        {154, 7, {{3,4,0},{5,0,0},{8,15,0},{9,19,0},{10,45,5}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,1,2,2,3,4,5,6,7,8
+      },
     },
     Female = {
-      Ranked = true,
-      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
-      ClothList = {
-        {53,0,{} },
-        {53,1,{} },
-        {53,2,{} },
-        {53,3,{} },
-        {53,4,{} },
-        {53,5,{} },
-        {53,6,{} },
-      }
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {151, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {151, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,0,0}} },
+        {151, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,0}} },
+        {151, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,1}} },
+        {151, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,2}} },
+        {151, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,3}} },
+        {151, 6, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,4}} },
+        {151, 7, {{3,3,0},{5,0,0},{8,14,0},{9,31,0},{10,53,5}} },
+      },
+      RankList = {
+        1,1,1,1,1,1,1,2,2,3,4,5,6,7,8
+      },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Pullover",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {72,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {67,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt in front of Pullover",
-    Male = {
-      Ranked = true,
-      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
-      ClothList = {
-        {92,16,{} },
-        {92,17,{} },
-        {92,18,{} },
-        {92,19,{} },
-        {92,20,{} },
-        {92,21,{} },
-        {92,22,{} },
-      }
-    },
-    Female = {
-      Ranked = true,
-      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
-      ClothList = {
-        {103,16,{} },
-        {103,17,{} },
-        {103,18,{} },
-        {103,19,{} },
-        {103,20,{} },
-        {103,21,{} },
-        {103,22,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt + Chest",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Eagle", -- the item will be categorized inside this category
     CategoryIndex = 3,
-    Name = "Radio + Badge",
+    Name = "Eagle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      RankList = {},
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {108, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {99, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Riot", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,0}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,1}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,4}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,5}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,6}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,2}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,3}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,1}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,2}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,3}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,4}} },
+        {150, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,0}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,1}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,4}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,5}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,6}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,2}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,3}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,1}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,2}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,3}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,4}} },
+        {147, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {93, 0, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {84, 0, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Bicycle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {93, 2, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {84, 2, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "K-9", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,0}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,1}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,4}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,5}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,6}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,2}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,3}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,1}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,2}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,3}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,4}} },
+        {101, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,0}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,1}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,4}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,5}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,6}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,2}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,3}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,1}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,2}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,3}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,4}} },
+        {92, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "K-9", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,0}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,1}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,4}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,5}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,6}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,2}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,3}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,1}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,2}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,3}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,4}} },
+        {102, 0, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,0}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,1}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,4}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,5}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,6}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,2}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,3}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,1}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,2}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,3}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,4}} },
+        {93, 0, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Bomb Squad", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,0}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,1}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,4}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,5}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,6}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,2}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,3}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,1}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,2}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,3}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,4}} },
+        {101, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,0}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,1}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,4}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,5}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,6}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,2}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,3}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,1}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,2}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,3}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,4}} },
+        {92, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Bomb Squad", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,0}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,1}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,4}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,5}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,6}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,2}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,3}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,1}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,2}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,3}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,4}} },
+        {102, 2, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,0}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,1}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,4}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,5}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,6}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,2}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,3}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,1}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,2}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,3}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,4}} },
+        {93, 2, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Bomb Squad K-9", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,0}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,1}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,4}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,5}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,6}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,2}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,12,3}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,1}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,2}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,3}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,4}} },
+        {101, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,0}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,1}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,4}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,5}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,6}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,2}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,11,3}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,1}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,2}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,3}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,4}} },
+        {92, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Bomb Squad K-9", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,0}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,1}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,4}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,5}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,6}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,2}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,15,3}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,1}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,2}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,3}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,4}} },
+        {102, 3, {{3,11,0},{5,0,0},{8,15,0},{9,0,0},{10,44,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,0}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,1}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,4}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,5}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,6}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,2}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,14,3}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,1}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,2}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,3}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,4}} },
+        {93, 3, {{3,9,0},{5,0,0},{8,14,0},{9,0,0},{10,52,5}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9,10,11,12,13,14
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {73, 17, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {224, 0, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 8, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Belt", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Eagle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {67, 0, {} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {49, 0, {} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class A",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
       ClothList = {
-        {67,0,{} },
+        {19,0,{{10,0,0}} },
+        {19,0,{{10,45,0}} },
+        {19,0,{{10,45,1}} },
+        {19,0,{{10,45,2}} },
+        {19,0,{{10,45,3}} },
+        {19,0,{{10,45,4}} },
+        {19,0,{{10,45,5}} },
       }
     },
     Female = {
-      Ranked = false,
-      RankList = {},
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
       ClothList = {
-        {49,0,{} },
+        {31,0,{{10,0,0}} },
+        {31,0,{{10,53,0}} },
+        {31,0,{{10,53,1}} },
+        {31,0,{{10,53,2}} },
+        {31,0,{{10,53,3}} },
+        {31,0,{{10,53,4}} },
+        {31,0,{{10,53,5}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {26,0,{{10,0,0}} },
+        {26,0,{{10,44,0}} },
+        {26,0,{{10,44,1}} },
+        {26,0,{{10,44,2}} },
+        {26,0,{{10,44,3}} },
+        {26,0,{{10,44,4}} },
+        {26,0,{{10,44,5}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {28,0,{{10,0,0}} },
+        {28,0,{{10,52,0}} },
+        {28,0,{{10,52,1}} },
+        {28,0,{{10,52,2}} },
+        {28,0,{{10,52,3}} },
+        {28,0,{{10,52,4}} },
+        {28,0,{{10,52,5}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B Collar",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {28,0,{{10,0,0}} },
+        {28,0,{{10,44,0}} },
+        {28,0,{{10,44,1}} },
+        {28,0,{{10,44,2}} },
+        {28,0,{{10,44,3}} },
+        {28,0,{{10,44,4}} },
+        {28,0,{{10,44,5}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,1,1,1,1,1,2,3,4,5,6,7},
+      ClothList = {
+        {30,0,{{10,0,0}} },
+        {30,0,{{10,52,0}} },
+        {30,0,{{10,52,1}} },
+        {30,0,{{10,52,2}} },
+        {30,0,{{10,52,3}} },
+        {30,0,{{10,52,4}} },
+        {30,0,{{10,52,5}} },
       }
     },
   },

--- a/Config/Wardrobes/Files/POL/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/POL/AccessoiresEUP.lua
@@ -67,19 +67,19 @@ POLAccessoires = {
     ComponentID = 0,
     Category = "Helmet",
     CategoryIndex = 0,
-    Name = "Riot Open Visor",
+    Name = "Riot",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {81,0,{} },
+        {126,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {80,0,{} },
+        {125,0,{} },
       }
     },
   },
@@ -88,103 +88,19 @@ POLAccessoires = {
     ComponentID = 0,
     Category = "Helmet",
     CategoryIndex = 0,
-    Name = "Riot Open Visor",
+    Name = "Riot",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {81,1,{} },
+        {124,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {80,1,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 0,
-    Name = "Riot Open Visor",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {81,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {80,2,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 0,
-    Name = "Riot Closed Visor",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {80,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {79,0,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 0,
-    Name = "Riot Closed Visor",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {80,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {79,1,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 0,
-    Name = "Riot Closed Visor",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {80,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {79,2,{} },
+        {123,0,{} },
       }
     },
   },
@@ -235,48 +151,6 @@ POLAccessoires = {
     ComponentID = 7,
     Category = "Holster",
     CategoryIndex = 0,
-    Name = "Leg",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {1,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {1,1,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Leg",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {1,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {1,2,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
     Name = "Belt Empty",
     Male = {
       Ranked = false,
@@ -311,48 +185,6 @@ POLAccessoires = {
       RankList = {},
       ClothList = {
         {3,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Leg Empty",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {3,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {3,1,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Leg Empty",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {3,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {3,2,{} },
       }
     },
   },
@@ -424,19 +256,19 @@ POLAccessoires = {
     ComponentID = 7,
     Category = "Holster",
     CategoryIndex = 0,
-    Name = "Leg",
+    Name = "Belt Training",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,0,{} },
+        {9,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {29,0,{} },
+        {9,0,{} },
       }
     },
   },
@@ -450,14 +282,14 @@ POLAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,1,{} },
+        {56,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {29,1,{} },
+        {33,0,{} },
       }
     },
   },
@@ -471,44 +303,23 @@ POLAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {43,0,{} },
+        {57,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {30,0,{} },
+        {34,0,{} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 7,
-    Category = "Holster",
+    Category = "Pistol",
     CategoryIndex = 0,
-    Name = "Leg Empty",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {43,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {30,1,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Leg",
+    Name = "SWAT Pants",
     Male = {
       Ranked = false,
       RankList = {},
@@ -526,106 +337,43 @@ POLAccessoires = {
   },
   {
     Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Leg Empty",
+    ComponentID = 9,
+    Category = "Vest",
+    CategoryIndex = 2,
+    Name = "Equip Vest",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {111,0,{} },
+        {1,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {82,0,{} },
+        {1,0,{} },
       }
     },
   },
   {
     Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Vest",
+    ComponentID = 9,
+    Category = "Vest",
+    CategoryIndex = 2,
+    Name = "Equip Vest",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {119,0,{} },
+        {1,1,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {0,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Vest",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {119,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {0,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Vest Empty",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {120,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {0,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 7,
-    Category = "Holster",
-    CategoryIndex = 0,
-    Name = "Vest Empty",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {120,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {0,0,{} },
+        {1,1,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/POL/LegsEUP.lua
+++ b/Config/Wardrobes/Files/POL/LegsEUP.lua
@@ -9,6 +9,48 @@ POLLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
+        {46,0,{{6,51,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {48,0,{{6,101,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Combat",
+    CategoryIndex = 3,
+    Name = "Standard Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {46,1,{{6,51,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {48,1,{{6,101,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Combat",
+    CategoryIndex = 3,
+    Name = "Alternative Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
         {31,0,{{6,25,0}} },
       }
     },
@@ -25,7 +67,7 @@ POLLegs = {
     ComponentID = 4,
     Category = "Combat",
     CategoryIndex = 3,
-    Name = "Standard Issue",
+    Name = "Alternative Issue",
     Male = {
       Ranked = false,
       RankList = {},
@@ -46,7 +88,7 @@ POLLegs = {
     ComponentID = 4,
     Category = "Combat",
     CategoryIndex = 3,
-    Name = "Standard Issue",
+    Name = "Alternative Issue",
     Male = {
       Ranked = false,
       RankList = {},
@@ -67,7 +109,7 @@ POLLegs = {
     ComponentID = 4,
     Category = "Combat",
     CategoryIndex = 3,
-    Name = "Standard Issue",
+    Name = "Alternative Issue",
     Male = {
       Ranked = false,
       RankList = {},
@@ -88,7 +130,7 @@ POLLegs = {
     ComponentID = 4,
     Category = "Combat",
     CategoryIndex = 3,
-    Name = "Standard Issue",
+    Name = "Alternative Issue",
     Male = {
       Ranked = false,
       RankList = {},
@@ -185,6 +227,27 @@ POLLegs = {
       RankList = {},
       ClothList = {
         {109,5,{{6,25,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 6,
+    Category = "Combat",
+    CategoryIndex = 3,
+    Name = "Boots",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {51,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {101,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/POL/TopsEUP.lua
+++ b/Config/Wardrobes/Files/POL/TopsEUP.lua
@@ -9,14 +9,14 @@ POLTops = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {49,0,{{3,4,0},{8,15,0},{9,0,0}} },
+        {49,0,{{3,4,0},{8,15,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,0,{{3,3,0},{8,14,0},{9,0,0}} },
+        {42,0,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
@@ -30,14 +30,14 @@ POLTops = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {49,1,{{3,4,0},{8,15,0},{9,0,0}} },
+        {49,1,{{3,4,0},{8,15,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,1,{{3,3,0},{8,14,0},{9,0,0}} },
+        {42,1,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
@@ -51,14 +51,14 @@ POLTops = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {49,2,{{3,4,0},{8,15,0},{9,0,0}} },
+        {49,2,{{3,4,0},{8,15,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,2,{{3,3,0},{8,14,0},{9,0,0}} },
+        {42,2,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
@@ -72,14 +72,14 @@ POLTops = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {49,3,{{3,4,0},{8,15,0},{9,0,0}} },
+        {49,3,{{3,4,0},{8,15,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,3,{{3,3,0},{8,14,0},{9,0,0}} },
+        {42,3,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
@@ -93,14 +93,14 @@ POLTops = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {49,4,{{3,4,0},{8,15,0},{9,0,0}} },
+        {49,4,{{3,4,0},{8,15,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,4,{{3,3,0},{8,14,0},{9,0,0}} },
+        {42,4,{{3,3,0},{8,14,0},{9,0,0},{5,0,0},{10,0,0}} },
       }
     },
   },
@@ -130,49 +130,7 @@ POLTops = {
     ComponentID = 8,
     Category = "Belt",
     CategoryIndex = 2,
-    Name = "Radio Baton",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {53,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {31,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt",
-    CategoryIndex = 2,
-    Name = "Radio Baton",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {38,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {34,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt",
-    CategoryIndex = 2,
-    Name = "Radio Baton",
+    Name = "Radio Taser",
     Male = {
       Ranked = false,
       RankList = {},
@@ -193,28 +151,7 @@ POLTops = {
     ComponentID = 8,
     Category = "Belt",
     CategoryIndex = 2,
-    Name = "Radio Baton",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {57,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {51,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt",
-    CategoryIndex = 2,
-    Name = "Radio Nightstick",
+    Name = "Radio Baton Flashlight",
     Male = {
       Ranked = false,
       RankList = {},
@@ -235,19 +172,19 @@ POLTops = {
     ComponentID = 8,
     Category = "Belt",
     CategoryIndex = 2,
-    Name = "Radio Nightstick",
+    Name = "Radio Baton Flashlight",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {55,0,{} },
+        {42,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {3,0,{} },
+        {8,0,{} },
       }
     },
   },
@@ -298,19 +235,124 @@ POLTops = {
     ComponentID = 8,
     Category = "Belt",
     CategoryIndex = 2,
+    Name = "Radio Baton",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {49,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {31,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 8,
+    Category = "Belt",
+    CategoryIndex = 2,
+    Name = "Radio Baton",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {49,1,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {31,1,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 8,
+    Category = "Belt",
+    CategoryIndex = 2,
+    Name = "Radio Baton Taser",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {53,1,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {27,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 8,
+    Category = "Belt",
+    CategoryIndex = 2,
+    Name = "Radio Baton",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {55,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {32,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 8,
+    Category = "Belt",
+    CategoryIndex = 2,
+    Name = "Radio Baton Taser",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {56,1,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {33,1,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 8,
+    Category = "Belt",
+    CategoryIndex = 2,
     Name = "Radio Nightstick",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {58,0,{} },
+        {57,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {35,0,{} },
+        {34,0,{} },
       }
     },
   },
@@ -319,19 +361,19 @@ POLTops = {
     ComponentID = 8,
     Category = "Belt",
     CategoryIndex = 2,
-    Name = "Radio Flashlight Baton",
+    Name = "Radio Baton Taser",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,0,{} },
+        {94,1,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {8,0,{} },
+        {101,1,{} },
       }
     },
   },
@@ -340,40 +382,19 @@ POLTops = {
     ComponentID = 8,
     Category = "Belt",
     CategoryIndex = 2,
-    Name = "Radio Flashlight Baton",
+    Name = "Radio Baton Leg Taser",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {42,1,{} },
+        {95,1,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {8,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt",
-    CategoryIndex = 2,
-    Name = "Radio Holster",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {122,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {152,0,{} },
+        {100,1,{} },
       }
     },
   },
@@ -424,54 +445,12 @@ POLTops = {
     ComponentID = 8,
     Category = "Shoulder",
     CategoryIndex = 3,
-    Name = "Holster",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {16,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {9,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Shoulder",
-    CategoryIndex = 3,
     Name = "Holster Empty",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
         {18,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {10,0,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Shoulder",
-    CategoryIndex = 3,
-    Name = "Holster Empty",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {18,1,{} },
       }
     },
     Female = {

--- a/Config/Wardrobes/Files/SAPR/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/SAPR/AccessoiresEUP.lua
@@ -1,194 +1,436 @@
 SAPRAccessoires = {
   {
-    Type = 0, -- 0: component, 1: prop
-    ComponentID = 9, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Chain", -- the item will be categorized inside this category
+    Type = 1,
+    ComponentID = 0,
+    Category = "Hat",
     CategoryIndex = 0,
-    Name = "Badge", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Winter",
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
-      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {17, 3, {} },
-      },
+      Ranked = false,
       RankList = {},
+      ClothList = {
+        {8,2,{} },
+      }
     },
     Female = {
       Ranked = false,
+      RankList = {},
       ClothList = {
-        {21, 3, {} },
-      },
-      RankList = {
-
-      },
+        {8,2,{} },
+      }
     },
-
   },
   {
-    Type = 0, -- 0: component, 1: prop
-    ComponentID = 9, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Chain", -- the item will be categorized inside this category
+    Type = 1,
+    ComponentID = 0,
+    Category = "Hat",
     CategoryIndex = 0,
-    Name = "Badge", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Winter",
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
-      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {17, 7, {} },
-      },
+      Ranked = false,
       RankList = {},
+      ClothList = {
+        {8,3,{} },
+      }
     },
     Female = {
       Ranked = false,
+      RankList = {},
       ClothList = {
-        {21, 7, {} },
-      },
-      RankList = {
-
-      },
+        {8,3,{} },
+      }
     },
-
   },
   {
-    Type = 0, -- 0: component, 1: prop
-    ComponentID = 9, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Tuck-in", -- the item will be categorized inside this category
+    Type = 1,
+    ComponentID = 0,
+    Category = "Hat",
+    CategoryIndex = 0,
+    Name = "Uniform",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {4,0,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {4,0,{} },
+      }
+    },
+  },
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Helmet",
+    CategoryIndex = 0,
+    Name = "Search and Rescue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {89,2,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {88,2,{} },
+      }
+    },
+  },
+
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Helmet",
+    CategoryIndex = 0,
+    Name = "Search and Rescue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {89,3,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {88,3,{} },
+      }
+    },
+  },
+
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Helmet",
+    CategoryIndex = 0,
+    Name = "Search and Rescue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {89,4,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {88,4,{} },
+      }
+    },
+  },
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Cap",
+    CategoryIndex = 0,
+    Name = "Cap",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {135,3,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {134,3,{} },
+      }
+    },
+  },
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Cap",
+    CategoryIndex = 0,
+    Name = "Cap",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {135,9,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {134,9,{} },
+      }
+    },
+  },
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Cap",
+    CategoryIndex = 0,
+    Name = "NPS",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {135,11,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {134,11,{} },
+      }
+    },
+  },
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Cap",
+    CategoryIndex = 0,
+    Name = "Cap",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {135,18,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {134,18,{} },
+      },
+      }
+  },
+  {
+    Type = 1,
+    ComponentID = 0,
+    Category = "Cap",
+    CategoryIndex = 0,
+    Name = "Lifeguard",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {135,19,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {134,19,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Vest",
+    CategoryIndex = 2,
+    Name = "Search and Rescue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {1,3,{} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {1,3,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Tuck-in",
     CategoryIndex = 3,
-    Name = "Badge + Handcuffs", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Badge + Handcuffs",
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
-      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {23, 3, {} },
-      },
+      Ranked = false,
       RankList = {},
+      ClothList = {
+        {23,2,{} },
+      }
     },
     Female = {
       Ranked = false,
+      RankList = {},
       ClothList = {
-        {25, 3, {} },
-      },
-      RankList = {
-
-      },
+        {25,2,{} },
+      }
     },
-
   },
   {
-    Type = 0, -- 0: component, 1: prop
-    ComponentID = 9, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Tuck-in", -- the item will be categorized inside this category
+    Type = 0,
+    ComponentID = 9,
+    Category = "Tuck-in",
     CategoryIndex = 3,
-    Name = "Badge + Handcuffs", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Badge + Handcuffs",
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
-      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {23, 7, {} },
-      },
+      Ranked = false,
       RankList = {},
+      ClothList = {
+        {23,7,{} },
+      }
     },
     Female = {
       Ranked = false,
-      ClothList = {
-        {25, 7, {} },
-      },
-      RankList = {
-
-      },
-    },
-
-  },
-  {
-    Type = 0, -- 0: component, 1: prop
-    ComponentID = 9, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Undershirt", -- the item will be categorized inside this category
-    CategoryIndex = 1,
-    Name = "Shirt in front of Pullover", -- the item will bear this name. If multiple options have the same name, you can choose different designs
-    Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
-      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {26,3, {} },
-      },
       RankList = {},
-    },
-    Female = {
-      Ranked = false,
       ClothList = {
-        {28, 3, {} },
-      },
-      RankList = {
-
-      },
+        {25,7,{} },
+      }
     },
-
   },
   {
-    Type = 1, -- 0: component, 1: prop
-    ComponentID = 0, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Hat", -- the item will be categorized inside this category
+    Type = 0,
+    ComponentID = 10,
+    Category = "Rank Insignia",
     CategoryIndex = 0,
-    Name = "Winter Hat", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Rank Insignia Class C",
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
-      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {8, 3, {} },
-      },
-      RankList = {},
+      Ranked = true,
+      RankList = {1,2,3,4,5,6,7,8,9,10},
+      ClothList = {
+        {0,0,{} },
+        {7,0,{} },
+        {44,0,{} },
+        {44,6,{} },
+        {44,7,{} },
+        {44,8,{} },
+        {44,9,{} },
+        {44,10,{} },
+        {43,0,{} },
+        {42,0,{} },
+      }
     },
     Female = {
-      Ranked = false,
+      Ranked = true,
+      RankList = {1,2,3,4,5,6,7,8,9,10},
       ClothList = {
-        {8, 3, {} },
-      },
-      RankList = {
-
-      },
+        {0,0,{} },
+        {6,0,{} },
+        {52,0,{} },
+        {52,6,{} },
+        {52,7,{} },
+        {52,8,{} },
+        {52,9,{} },
+        {52,10,{} },
+        {51,0,{} },
+        {50,0,{} },
+      }
     },
-
   },
   {
-    Type = 1, -- 0: component, 1: prop
-    ComponentID = 0, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Cap", -- the item will be categorized inside this category
+    Type = 0,
+    ComponentID = 10,
+    Category = "Rank Insignia",
     CategoryIndex = 0,
-    Name = "Cap", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Rank Insignia Class B",
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
-      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {10, 1, {} },
-      },
-      RankList = {},
+      Ranked = true,
+      RankList = {1,2,3,4,5,6,7,8,9,10},
+      ClothList = {
+        {0,0,{} },
+        {11,5,{} },
+        {44,0,{} },
+        {44,6,{} },
+        {44,7,{} },
+        {44,8,{} },
+        {44,9,{} },
+        {44,10,{} },
+        {43,0,{} },
+        {42,0,{} },
+      }
     },
     Female = {
-      Ranked = false,
+      Ranked = true,
+      RankList = {1,2,3,4,5,6,7,8,9,10},
       ClothList = {
-        {10, 1, {} },
-      },
-      RankList = {
-
-      },
+        {0,0,{} },
+        {10,5,{} },
+        {52,0,{} },
+        {52,6,{} },
+        {52,7,{} },
+        {52,8,{} },
+        {52,9,{} },
+        {52,10,{} },
+        {51,0,{} },
+        {50,0,{} },
+      }
     },
-
   },
   {
-    Type = 1, -- 0: component, 1: prop
-    ComponentID = 0, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Cap", -- the item will be categorized inside this category
+    Type = 0,
+    ComponentID = 10,
+    Category = "Rank Insignia",
     CategoryIndex = 0,
-    Name = "Cap", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Rank Insignia Class A",
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
-      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {10, 3, {} },
-      },
+      Ranked = true,
+      RankList = {1,2,3,4,5,6,7,8,9,10},
+      ClothList = {
+        {0,0,{} },
+        {11,5,{} },
+        {45,0,{} },
+        {45,6,{} },
+        {45,7,{} },
+        {45,8,{} },
+        {45,9,{} },
+        {45,10,{} },
+        {45,11,{} },
+        {45,12,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,2,3,4,5,6,7,8,9,10},
+      ClothList = {
+        {0,0,{} },
+        {10,5,{} },
+        {53,0,{} },
+        {53,6,{} },
+        {53,7,{} },
+        {53,8,{} },
+        {53,9,{} },
+        {53,10,{} },
+        {53,11,{} },
+        {53,12,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 5,
+    Category = "Badges",
+    CategoryIndex = 0,
+    Name = "Badge",
+    Male = {
+      Ranked = false,
       RankList = {},
+      ClothList = {
+        {36,0,{} },
+      }
     },
     Female = {
       Ranked = false,
+      RankList = {},
       ClothList = {
-        {10, 6, {} },
-      },
-      RankList = {
-
-      },
+        {36,0,{} },
+      }
     },
-
   },
 }

--- a/Config/Wardrobes/Files/SAPR/LegsEUP.lua
+++ b/Config/Wardrobes/Files/SAPR/LegsEUP.lua
@@ -2,20 +2,44 @@ SAPRLegs = {
   {
     Type = 0, -- 0: component, 1: prop
     ComponentID = 4, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Pants", -- the item will be categorized inside this category
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 2,
     Name = "Standard Issue", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
       Ranked = false, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {25, 0, {{6,51,0}} },
+        {101,1, {{6,25,0}} },
       },
       RankList = {},
     },
     Female = {
       Ranked = false,
       ClothList = {
-        {41, 1, {{6,52,0}} },
+        {105, 1, {{6,25,0}} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 4, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Search and Rescue", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {44,0, {{6,25,0}} },
+      },
+      RankList = {},
+    },
+    Female = {
+      Ranked = false,
+      ClothList = {
+        {46, 0, {{6,25,0}} },
       },
       RankList = {
 

--- a/Config/Wardrobes/Files/SAPR/TopsEUP.lua
+++ b/Config/Wardrobes/Files/SAPR/TopsEUP.lua
@@ -4,21 +4,170 @@ SAPRTops = {
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
     Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Class C", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
+      Ranked = true, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {81, 0, {{3,0,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {40, 0, {{3,14,0},{8,14,0},{9,0,0}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,1,0}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {190, 5, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
       },
       RankList = {
-
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,1,0}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {192, 5, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class C", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,1,0}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {190, 6, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,1,0}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {192, 6, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class C", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,1,0}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {190, 19, {{3,11,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,1,0}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {192, 19, {{3,9,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {193, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {195, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
       },
     },
 
@@ -28,21 +177,41 @@ SAPRTops = {
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
     Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
+      Ranked = true, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {81, 1, {{3,0,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {40, 1, {{3,14,0},{8,14,0},{9,0,0}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {193, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
       },
       RankList = {
-
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {195, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
       },
     },
 
@@ -52,21 +221,41 @@ SAPRTops = {
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
     Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Long Sleeve", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
+      Ranked = true, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {80, 0, {{3,4,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {40, 0, {{3,14,0},{8,14,0},{9,0,0}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {193, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
       },
       RankList = {
-
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,0}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {195, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
       },
     },
 
@@ -76,21 +265,41 @@ SAPRTops = {
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
     Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Long Sleeve", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "Class A", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false, -- defines if the clothing has rank insignia
+      Ranked = true, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {80, 1, {{3,4,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {40, 1, {{3,14,0},{8,14,0},{9,0,0}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,0}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,6}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,7}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,8}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,9}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,10}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,11}} },
+        {200, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,12}} },
       },
       RankList = {
-
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,0}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,6}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,7}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,8}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,9}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,10}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,11}} },
+        {202, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
       },
     },
 
@@ -98,20 +307,626 @@ SAPRTops = {
   {
     Type = 0, -- 0: component, 1: prop
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Jacket T1", -- the item will be categorized inside this category
-    CategoryIndex = 1,
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class A", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,0}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,6}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,7}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,8}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,9}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,10}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,11}} },
+        {200, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,0}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,6}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,7}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,8}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,9}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,10}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,11}} },
+        {202, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class A", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,0}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,6}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,7}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,8}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,9}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,10}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,11}} },
+        {200, 19, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,45,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,0}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,6}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,7}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,8}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,9}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,10}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,11}} },
+        {202, 19, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,53,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B Collar", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {196, 5, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,2}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,3}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {198, 5, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B Collar", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {196, 6, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,2}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,3}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {198, 6, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B Collar", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,11,0}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,0}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {196, 8, {{3,4,0},{5,36,0},{8,15,0},{9,0,0},{10,42,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,0}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,2}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,10,3}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {198, 8, {{3,3,0},{5,36,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,0,0}} },
+        {21, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,0,0}} },
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,0}} },
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,6}} },
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,7}} },
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,8}} },
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,9}} },
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,10}} },
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,11}} },
+        {21, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,0,0}} },
+        {19, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,0,0}} },
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,0}} },
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,6}} },
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,7}} },
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,8}} },
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,9}} },
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,10}} },
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,11}} },
+        {19, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,0,0}} },
+        {21, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,0,0}} },
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,0}} },
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,6}} },
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,7}} },
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,8}} },
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,9}} },
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,10}} },
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,11}} },
+        {21, 2, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,0,0}} },
+        {19, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,0,0}} },
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,0}} },
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,6}} },
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,7}} },
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,8}} },
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,9}} },
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,10}} },
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,11}} },
+        {19, 2, {{3,3,0},{5,0,0},{8,14,0},{9,31,},{10,53,12}} },
+      },
+      RankList = {
+        1,2,3,4,5,6,7,8,9,10
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,0,0}} },
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,0}} },
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,6}} },
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,7}} },
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,8}} },
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,9}} },
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,10}} },
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,11}} },
+        {187, 4, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,12}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,0,0}} },
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,0}} },
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,6}} },
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,7}} },
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,8}} },
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,9}} },
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,10}} },
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,11}} },
+        {189, 4, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,12}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,0,0}} },
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,0}} },
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,6}} },
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,7}} },
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,8}} },
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,9}} },
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,10}} },
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,11}} },
+        {187, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,5},{10,45,12}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,0,0}} },
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,0}} },
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,6}} },
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,7}} },
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,8}} },
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,9}} },
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,10}} },
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,11}} },
+        {189, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,5},{10,53,12}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,0,0}} },
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,0}} },
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,6}} },
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,7}} },
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,8}} },
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,9}} },
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,10}} },
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,11}} },
+        {187, 11, {{3,4,0},{5,0,0},{8,15,0},{9,19,4},{10,45,12}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,0,0}} },
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,0}} },
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,6}} },
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,7}} },
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,8}} },
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,9}} },
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,10}} },
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,11}} },
+        {189, 11, {{3,3,0},{5,0,0},{8,14,0},{9,31,4},{10,53,12}} },
+      },
+      RankList = {
+        1,1,2,3,4,5,6,7,8,9
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T4", -- the item will be categorized inside this category
+    CategoryIndex = 4,
     Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
       Ranked = false, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {156, 1, {{3,4,0},{8,93,0},{9,0,0}} },
+        {266, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
       },
-      RankList = {},
+      RankList = {
+
+      },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {153, 1, {{3,3,0},{8,101,0},{9,0,0}} },
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {275, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T4", -- the item will be categorized inside this category
+    CategoryIndex = 4,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {266, 4, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {275, 4, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T4", -- the item will be categorized inside this category
+    CategoryIndex = 4,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {266, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {275, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {311, 9, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {335, 9, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {311, 10, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {335, 10, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {311, 12, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {335, 12, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {311, 25, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {335, 25, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Pullover", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {239, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {223, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
 
@@ -122,20 +937,22 @@ SAPRTops = {
   {
     Type = 0, -- 0: component, 1: prop
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Jacket T2", -- the item will be categorized inside this category
-    CategoryIndex = 2,
-    Name = "Winter", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Pullover", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
       Ranked = false, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {17, 4, {{3,4,0},{8,15,0},{9,26,3}} },
+        {239, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
       },
-      RankList = {},
+      RankList = {
+
+      },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {21, 4, {{3,3,0},{8,14,0},{9,28,3}} },
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {223, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
 
@@ -146,20 +963,22 @@ SAPRTops = {
   {
     Type = 0, -- 0: component, 1: prop
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Jacket T2", -- the item will be categorized inside this category
-    CategoryIndex = 2,
-    Name = "Winter Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Pullover", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
       Ranked = false, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {17, 5, {{3,4,0},{8,15,0},{9,26,3}} },
+        {239, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
       },
-      RankList = {},
+      RankList = {
+
+      },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {21, 5, {{3,3,0},{8,14,0},{9,28,3}} },
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {223, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
 
@@ -170,25 +989,275 @@ SAPRTops = {
   {
     Type = 0, -- 0: component, 1: prop
     ComponentID = 8, -- =component-ID in the FiveM-native SetPedComponentVariation
-    Category = "Undershirt", -- the item will be categorized inside this category
-    CategoryIndex = 1,
-    Name = "Shirt in front of Pullover", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Category = "Shoulder", -- the item will be categorized inside this category
+    CategoryIndex = 3,
+    Name = "Chain", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
       Ranked = false, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
-        {93, 0, {} },
+        {115, 3, {} },
       },
-      RankList = {},
+      RankList = {
+
+      },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {101,0, {} },
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {81, 3, {} },
       },
       RankList = {
 
       },
     },
 
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 8, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Shoulder", -- the item will be categorized inside this category
+    CategoryIndex = 3,
+    Name = "Radio", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {68, 0, {} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {48, 0, {} },
+      },
+      RankList = {
+
+      },
+    },
+
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class A",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {19,4,{{10,0,0}} },
+        {19,4,{{10,45,0}} },
+        {19,4,{{10,45,6}} },
+        {19,4,{{10,45,7}} },
+        {19,4,{{10,45,8}} },
+        {19,4,{{10,45,9}} },
+        {19,4,{{10,45,10}} },
+        {19,4,{{10,45,11}} },
+        {19,4,{{10,45,12}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {31,4,{{10,0,0}} },
+        {31,4,{{10,53,0}} },
+        {31,4,{{10,53,6}} },
+        {31,4,{{10,53,7}} },
+        {31,4,{{10,53,8}} },
+        {31,4,{{10,53,9}} },
+        {31,4,{{10,53,10}} },
+        {31,4,{{10,53,11}} },
+        {31,4,{{10,53,12}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class A",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {19,5,{{10,0,0}} },
+        {19,5,{{10,45,0}} },
+        {19,5,{{10,45,6}} },
+        {19,5,{{10,45,7}} },
+        {19,5,{{10,45,8}} },
+        {19,5,{{10,45,9}} },
+        {19,5,{{10,45,10}} },
+        {19,5,{{10,45,11}} },
+        {19,5,{{10,45,12}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {31,5,{{10,0,0}} },
+        {31,5,{{10,53,0}} },
+        {31,5,{{10,53,6}} },
+        {31,5,{{10,53,7}} },
+        {31,5,{{10,53,8}} },
+        {31,5,{{10,53,9}} },
+        {31,5,{{10,53,10}} },
+        {31,5,{{10,53,11}} },
+        {31,5,{{10,53,12}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B Collar",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {26,3,{{10,0,0}} },
+        {26,3,{{10,44,0}} },
+        {26,3,{{10,44,6}} },
+        {26,3,{{10,44,7}} },
+        {26,3,{{10,44,8}} },
+        {26,3,{{10,44,9}} },
+        {26,3,{{10,44,10}} },
+        {26,3,{{10,43,0}} },
+        {26,3,{{10,42,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {28,3,{{10,0,0}} },
+        {28,3,{{10,52,0}} },
+        {28,3,{{10,52,6}} },
+        {28,3,{{10,52,7}} },
+        {28,3,{{10,52,8}} },
+        {28,3,{{10,52,9}} },
+        {28,3,{{10,52,10}} },
+        {28,3,{{10,51,0}} },
+        {28,3,{{10,50,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B Collar",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {26,4,{{10,0,0}} },
+        {26,4,{{10,44,0}} },
+        {26,4,{{10,44,6}} },
+        {26,4,{{10,44,7}} },
+        {26,4,{{10,44,8}} },
+        {26,4,{{10,44,9}} },
+        {26,4,{{10,44,10}} },
+        {26,4,{{10,43,0}} },
+        {26,4,{{10,42,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {28,4,{{10,0,0}} },
+        {28,4,{{10,52,0}} },
+        {28,4,{{10,52,6}} },
+        {28,4,{{10,52,7}} },
+        {28,4,{{10,52,8}} },
+        {28,4,{{10,52,9}} },
+        {28,4,{{10,52,10}} },
+        {28,4,{{10,51,0}} },
+        {28,4,{{10,50,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {28,8,{{10,0,0}} },
+        {28,8,{{10,44,0}} },
+        {28,8,{{10,44,6}} },
+        {28,8,{{10,44,7}} },
+        {28,8,{{10,44,8}} },
+        {28,8,{{10,44,9}} },
+        {28,8,{{10,44,10}} },
+        {28,8,{{10,43,0}} },
+        {28,8,{{10,42,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {30,8,{{10,0,0}} },
+        {30,8,{{10,52,0}} },
+        {30,8,{{10,52,6}} },
+        {30,8,{{10,52,7}} },
+        {30,8,{{10,52,8}} },
+        {30,8,{{10,52,9}} },
+        {30,8,{{10,52,10}} },
+        {30,8,{{10,51,0}} },
+        {30,8,{{10,50,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {28,5,{{10,0,0}} },
+        {28,5,{{10,44,0}} },
+        {28,5,{{10,44,6}} },
+        {28,5,{{10,44,7}} },
+        {28,5,{{10,44,8}} },
+        {28,5,{{10,44,9}} },
+        {28,5,{{10,44,10}} },
+        {28,5,{{10,43,0}} },
+        {28,5,{{10,42,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {30,5,{{10,0,0}} },
+        {30,5,{{10,52,0}} },
+        {30,5,{{10,52,6}} },
+        {30,5,{{10,52,7}} },
+        {30,5,{{10,52,8}} },
+        {30,5,{{10,52,9}} },
+        {30,5,{{10,52,10}} },
+        {30,5,{{10,51,0}} },
+        {30,5,{{10,50,0}} },
+      }
+    },
   },
 }

--- a/Config/Wardrobes/Files/SASP/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/SASP/AccessoiresEUP.lua
@@ -4,40 +4,19 @@ SASPAccessoires = {
     ComponentID = 0,
     Category = "Hat",
     CategoryIndex = 0,
-    Name = "Winter",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {8,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {8,2,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Hat",
-    CategoryIndex = 0,
     Name = "Uniform",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {13,2,{} },
+        {31,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {13,2,{} },
+        {30,0,{} },
       }
     },
   },
@@ -72,14 +51,14 @@ SASPAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {44,0,{} },
+        {135,20,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {43,0,{} },
+        {134,20,{} },
       }
     },
   },
@@ -114,69 +93,6 @@ SASPAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {17,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {21,2,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Chain",
-    CategoryIndex = 2,
-    Name = "Badge",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {17,5,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {21,6,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Traffic Vest",
-    CategoryIndex = 2,
-    Name = "SAHP",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {18,3,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {19,2,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Chain",
-    CategoryIndex = 2,
-    Name = "Pass",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
         {21,7,{} },
       }
     },
@@ -198,56 +114,14 @@ SASPAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {23,2,{} },
+        {35,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {25,2,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Tuck-in",
-    CategoryIndex = 3,
-    Name = "Badge + Handcuffs",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {23,6,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {25,6,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 9,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt in front of Pullover",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {26,2,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {28,2,{} },
+        {39,0,{} },
       }
     },
   },
@@ -256,42 +130,130 @@ SASPAccessoires = {
     ComponentID = 10,
     Category = "Rank Insignia",
     CategoryIndex = 0,
-    Name = "Rank Insignia",
+    Name = "Rank Insignia Class C",
     Male = {
       Ranked = true,
-      RankList = {1,1,2,2,1,1,1,1,1,1,1},
+      RankList = {1,1,2,2,3,4,5,6,7,8,9},
       ClothList = {
         {0,0,{} },
-        {7,0,{} },
+        {6,0,{} },
+        {44,6,{} },
+        {44,7,{} },
+        {44,8,{} },
+        {44,9,{} },
+        {44,10,{} },
+        {43,0,{} },
+        {42,0,{} },
       }
     },
     Female = {
       Ranked = true,
-      RankList = {1,1,2,2,1,1,1,1,1,1,1},
+      RankList = {1,1,2,2,3,4,5,6,7,8,9},
       ClothList = {
         {0,0,{} },
-        {1,0,{} },
+        {6,0,{} },
+        {52,6,{} },
+        {52,7,{} },
+        {52,8,{} },
+        {52,9,{} },
+        {52,10,{} },
+        {51,0,{} },
+        {50,0,{} },
       }
     },
   },
   {
     Type = 0,
     ComponentID = 10,
-    Category = "Sticker",
-    CategoryIndex = 1,
-    Name = "Logo",
+    Category = "Rank Insignia",
+    CategoryIndex = 0,
+    Name = "Rank Insignia Class B",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {0,0,{} },
+        {11,5,{} },
+        {44,6,{} },
+        {44,7,{} },
+        {44,8,{} },
+        {44,9,{} },
+        {44,10,{} },
+        {43,0,{} },
+        {42,0,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {0,0,{} },
+        {10,5,{} },
+        {52,6,{} },
+        {52,7,{} },
+        {52,8,{} },
+        {52,9,{} },
+        {52,10,{} },
+        {51,0,{} },
+        {50,0,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 10,
+    Category = "Rank Insignia",
+    CategoryIndex = 0,
+    Name = "Rank Insignia Class A",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,2,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {0,0,{} },
+        {11,5,{} },
+        {45,6,{} },
+        {45,7,{} },
+        {45,8,{} },
+        {45,9,{} },
+        {45,10,{} },
+        {45,11,{} },
+        {45,12,{} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,2,2,3,4,5,6,7,8,9},
+      ClothList = {
+        {0,0,{} },
+        {10,5,{} },
+        {53,6,{} },
+        {53,7,{} },
+        {53,8,{} },
+        {53,9,{} },
+        {53,10,{} },
+        {53,11,{} },
+        {53,12,{} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 5,
+    Category = "Badges",
+    CategoryIndex = 0,
+    Name = "Badge",
     Male = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {9,0,{} },
+        {55,0,{} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {11,4,{} },
+        {55,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/SASP/LegsEUP.lua
+++ b/Config/Wardrobes/Files/SASP/LegsEUP.lua
@@ -9,14 +9,57 @@ SASPLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {25,1,{{6,51,0}} },
+        {25,1,{{6,25,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {41,2,{{6,52,0}} },
+        {41,2,{{6,25,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Eagle",
+    CategoryIndex = 2,
+    Name = "Standard Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {64,2,{{6,25,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {66,2,{{6,25,0}} },
+      }
+    },
+  },
+
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Eagle",
+    CategoryIndex = 2,
+    Name = "CVE",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {64,3,{{6,25,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {66,3,{{6,25,0}} },
       }
     },
   },
@@ -30,14 +73,35 @@ SASPLegs = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {32,0,{{6,30,0}} },
+        {32,0,{{6,13,0}} },
       }
     },
     Female = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {31,0,{{6,9,0}} },
+        {31,0,{{6,26,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Combat Uniform",
+    CategoryIndex = 3,
+    Name = "Standard Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {125,1,{{6,51,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {131,1,{{6,101,0}} },
       }
     },
   },

--- a/Config/Wardrobes/Files/SASP/TopsEUP.lua
+++ b/Config/Wardrobes/Files/SASP/TopsEUP.lua
@@ -1,382 +1,634 @@
 SASPTops = {
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve",
+    Name = "Class C", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      ClothList = {
-        {118, 0, {{3,0,0},{8,15,0},{9,0,0}} },
-        {118, 1, {{3,0,0},{8,15,0},{9,0,0}} },
-        {118, 2, {{3,0,0},{8,15,0},{9,0,0}} },
-        {118, 3, {{3,0,0},{8,15,0},{9,0,0}} },
-        {118, 4, {{3,0,0},{8,15,0},{9,0,0}} },
-        {118, 5, {{3,0,0},{8,15,0},{9,0,0}} },
-        {118, 6, {{3,0,0},{8,15,0},{9,0,0}} },
-        {118, 7, {{3,0,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
-      },
-    },
-    Female = {
-      Ranked = true,
-      ClothList = {
-        {25, 0, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 1, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 2, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 3, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 4, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 5, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 6, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 7, {{3,14,0},{8,14,0},{9,0,0}} },
-      },
-      RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
-      },
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
-    CategoryIndex = 0,
-    Name = "Long Sleeve",
-    Male = {
-      Ranked = true,
-      ClothList = {
-        {26, 0, {{3,4,0},{8,15,0},{9,0,0}} },
-        {26, 1, {{3,4,0},{8,15,0},{9,0,0}} },
-        {26, 2, {{3,4,0},{8,15,0},{9,0,0}} },
-        {26, 3, {{3,4,0},{8,15,0},{9,0,0}} },
-        {26, 4, {{3,4,0},{8,15,0},{9,0,0}} },
-        {26, 5, {{3,4,0},{8,15,0},{9,0,0}} },
-        {26, 6, {{3,4,0},{8,15,0},{9,0,0}} },
-        {26, 7, {{3,4,0},{8,15,0},{9,0,0}} },
-        {26, 8, {{3,4,0},{8,15,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,7,0}} },
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {190, 4, {{3,11,0},{5,55,0},{8,15,0},{9,0,0},{10,42,0}} },
       },
       RankList = {
         1,1,2,2,3,4,5,6,7,8,9
       },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {25, 0, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 1, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 2, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 3, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 4, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 5, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 6, {{3,14,0},{8,14,0},{9,0,0}} },
-        {25, 7, {{3,14,0},{8,14,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,6,0}} },
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {192, 4, {{3,9,0},{5,55,0},{8,14,0},{9,0,0},{10,50,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
+        1,1,2,2,3,4,5,6,7,8,9
       },
     },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Uniform",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Medium Sleeve K-9",
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      ClothList = {
-        {31, 4, {{3,0,0},{8,15,0},{9,0,0}} },
-        {31, 5, {{3,0,0},{8,15,0},{9,0,0}} },
-        {31, 6, {{3,0,0},{8,15,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,11,5}} },
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {193, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,42,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,3,3,3,3,3
+        1,1,2,2,3,4,5,6,7,8,9
       },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {33, 4, {{3,14,0},{8,14,0},{9,0,0}} },
-        {33, 5, {{3,14,0},{8,14,0},{9,0,0}} },
-        {33, 6, {{3,14,0},{8,14,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,10,5}} },
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {195, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,50,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,3,3,3,3,3
+        1,1,2,2,3,4,5,6,7,8,9
       },
     },
+
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "T-Shirt",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "Standard",
+    Name = "Class A", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      ClothList = {
-        {51, 1, {{3,0,0},{8,15,0},{9,0,0}} },
-      },
-      RankList = {},
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {44, 1, {{3,14,0},{8,14,0},{9,0,0}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,11,5}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,45,6}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,45,7}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,45,8}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,45,9}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,45,10}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,45,11}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,45,12}} },
+        {200, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,45,13}} },
       },
       RankList = {
+        1,1,2,2,3,4,5,6,7,8,9
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,10,5}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,53,6}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,53,7}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,53,8}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,53,9}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,53,10}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,53,11}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,53,12}} },
+        {202, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,53,13}} },
+      },
+      RankList = {
+        1,1,2,2,3,4,5,6,7,8,9
+      },
+    },
 
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Uniform", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B Collar", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,11,5}} },
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {196, 4, {{3,4,0},{5,55,0},{8,15,0},{9,0,0},{10,42,0}} },
+      },
+      RankList = {
+        1,1,2,2,3,4,5,6,7,8,9
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,10,5}} },
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {198, 4, {{3,3,0},{5,55,0},{8,14,0},{9,0,0},{10,50,0}} },
+      },
+      RankList = {
+        1,1,2,2,3,4,5,6,7,8,9
       },
     },
   },
   {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Blue",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {35, 5, {{3,4,0},{8,65,16},{9,0,0}} },
-      },
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {94,0, {{3,4,0},{8,45,16},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Blue",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {36, 5, {{3,4,0},{8,65,16},{9,0,0}} },
-      },
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {94,0, {{3,4,0},{8,45,16},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Black",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {103, 0, {{3,4,0},{8,65,16},{9,0,0}} },
-      },
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {94,0, {{3,4,0},{8,45,16},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T1",
-    CategoryIndex = 1,
-    Name = "Biker",
-    Male = {
-      Ranked = false,
-      ClothList = {
-        {64, 0, {{3,4,0},{8,65,16},{9,0,0}} },
-      },
-    },
-    Female = {
-      Ranked = false,
-      ClothList = {
-        {34,0, {{3,4,0},{8,45,16},{9,0,0}} },
-      },
-      RankList = {
-
-      },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 11,
-    Category = "Jacket T2",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
     CategoryIndex = 2,
-    Name = "Winter",
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      ClothList = {
-        {17, 3, {{3,4,0},{8,15,0},{9,26,2}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {19, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,0,0}} },
+        {19, 1, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,0,0}} },
+        {19, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,6}} },
+        {19, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,7}} },
+        {19, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,8}} },
+        {19, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,9}} },
+        {19, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,10}} },
+        {19, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,11}} },
+        {19, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,12}} },
+      },
+      RankList = {
+        1,1,2,2,3,4,5,6,7,8,9
       },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {21,3, {{3,4,0},{8,14,0},{9,28,2}} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {30, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,0,0}} },
+        {30, 1, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,0,0}} },
+        {30, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,6}} },
+        {30, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,7}} },
+        {30, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,8}} },
+        {30, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,9}} },
+        {30, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,10}} },
+        {30, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,11}} },
+        {30, 0, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,12}} },
       },
       RankList = {
-
+        1,1,2,2,3,4,5,6,7,8,9
       },
-    }
+    },
   },
   {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Belt",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
     CategoryIndex = 2,
-    Name = "Radio + Badge",
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = false,
-      ClothList = {
-        {43, 0, {} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {187, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,0,0}} },
+        {187, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,6}} },
+        {187, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,7}} },
+        {187, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,8}} },
+        {187, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,9}} },
+        {187, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,10}} },
+        {187, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,11}} },
+        {187, 3, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,12}} },
+      },
+      RankList = {
+        1,1,1,1,2,3,4,5,6,7,8
       },
     },
     Female = {
-      Ranked = false,
-      ClothList = {
-        {30,0, {} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {189, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,0,0}} },
+        {189, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,6}} },
+        {189, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,7}} },
+        {189, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,8}} },
+        {189, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,9}} },
+        {189, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,10}} },
+        {189, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,11}} },
+        {189, 3, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,12}} },
+      },
+      RankList = {
+        1,1,1,1,2,3,4,5,6,7,8
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {35, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,0,0}} },
+        {35, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,6}} },
+        {35, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,7}} },
+        {35, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,8}} },
+        {35, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,9}} },
+        {35, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,10}} },
+        {35, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,11}} },
+        {35, 5, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,12}} },
+      },
+      RankList = {
+        1,1,1,1,2,3,4,5,6,7,8
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {168, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,0,0}} },
+        {168, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,6}} },
+        {168, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,7}} },
+        {168, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,8}} },
+        {168, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,9}} },
+        {168, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,10}} },
+        {168, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,11}} },
+        {168, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,12}} },
+      },
+      RankList = {
+        1,1,1,1,2,3,4,5,6,7,8
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T2", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {53, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,0,0}} },
+        {53, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,6}} },
+        {53, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,7}} },
+        {53, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,8}} },
+        {53, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,9}} },
+        {53, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,10}} },
+        {53, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,11}} },
+        {53, 0, {{3,4,0},{5,0,0},{8,15,0},{9,19,3},{10,45,12}} },
+      },
+      RankList = {
+        1,1,1,1,2,3,4,5,6,7,8
+      },
+    },
+    Female = {
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {46, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,0,0}} },
+        {46, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,6}} },
+        {46, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,7}} },
+        {46, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,8}} },
+        {46, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,9}} },
+        {46, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,10}} },
+        {46, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,11}} },
+        {46, 5, {{3,3,0},{5,0,0},{8,14,0},{9,31,3},{10,53,12}} },
+      },
+      RankList = {
+        1,1,1,1,2,3,4,5,6,7,8
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Eagle", -- the item will be categorized inside this category
+    CategoryIndex = 3,
+    Name = "Eagle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {108, 3, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
 
       },
-    }
-  },
-  {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt",
-    Male = {
-      Ranked = true,
-      ClothList = {
-        {65, 8, {} },
-        {65, 9, {} },
-        {65, 10, {} },
-        {65, 11, {} },
-        {65, 12, {} },
-        {65, 13, {} },
-        {65, 14, {} },
-        {65, 15, {} },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {99, 3, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Eagle", -- the item will be categorized inside this category
+    CategoryIndex = 3,
+    Name = "CVE", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {108, 4, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
       },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {45, 8, {} },
-        {45, 9, {} },
-        {45, 10, {} },
-        {45, 11, {} },
-        {45, 12, {} },
-        {45, 13, {} },
-        {45, 14, {} },
-        {45, 15, {} },
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {99, 4, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
+
       },
-    }
+    },
   },
   {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt + Tie",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Riot", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      ClothList = {
-        {66, 8, {} },
-        {66, 9, {} },
-        {66, 10, {} },
-        {66, 11, {} },
-        {66, 12, {} },
-        {66, 13, {} },
-        {66, 14, {} },
-        {66, 15, {} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,11,5}} },
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,6}} },
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,7}} },
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,8}} },
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,9}} },
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,44,10}} },
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,43,0}} },
+        {150, 5, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,42,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
+        1,1,2,2,3,4,5,6,7,8,9
       },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {45, 8, {} },
-        {45, 9, {} },
-        {45, 10, {} },
-        {45, 11, {} },
-        {45, 12, {} },
-        {45, 13, {} },
-        {45, 14, {} },
-        {45, 15, {} },
+      Ranked = true, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,10,5}} },
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,6}} },
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,7}} },
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,8}} },
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,9}} },
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,52,10}} },
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,51,0}} },
+        {147, 5, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,50,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
+        1,1,2,2,3,4,5,6,7,8,9
       },
-    }
+    },
   },
   {
-    Type = 0,
-    ComponentID = 8,
-    Category = "Undershirt",
-    CategoryIndex = 1,
-    Name = "Shirt in front of Pullover",
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Special Uniforms", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "T-Shirt", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
-      Ranked = true,
-      ClothList = {
-        {92, 8, {} },
-        {92, 9, {} },
-        {92, 10, {} },
-        {92, 11, {} },
-        {92, 12, {} },
-        {92, 13, {} },
-        {92, 14, {} },
-        {92, 15, {} },
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {311, 4, {{3,0,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
+
       },
     },
     Female = {
-      Ranked = true,
-      ClothList = {
-        {103, 8, {} },
-        {103, 9, {} },
-        {103, 10, {} },
-        {103, 11, {} },
-        {103, 12, {} },
-        {103, 13, {} },
-        {103, 14, {} },
-        {103, 15, {} },
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {335, 4, {{3,14,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
       },
       RankList = {
-        1,1,1,1,2,3,4,5,6,7,8
+
       },
-    }
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T4", -- the item will be categorized inside this category
+    CategoryIndex = 4,
+    Name = "Jacket", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {266,9, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {275, 9, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 8, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Belt", -- the item will be categorized inside this category
+    CategoryIndex = 2,
+    Name = "Eagle", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {48, 0, {} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {29, 0, {} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class A",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,3,4,5,6,7,8},
+      ClothList = {
+        {19,3,{{10,0,0}} },
+        {19,3,{{10,45,6}} },
+        {19,3,{{10,45,7}} },
+        {19,3,{{10,45,8}} },
+        {19,3,{{10,45,9}} },
+        {19,3,{{10,45,10}} },
+        {19,3,{{10,45,11}} },
+        {19,3,{{10,45,12}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,3,4,5,6,7,8},
+      ClothList = {
+        {31,3,{{10,0,0}} },
+        {31,3,{{10,53,6}} },
+        {31,3,{{10,53,7}} },
+        {31,3,{{10,53,8}} },
+        {31,3,{{10,53,9}} },
+        {31,3,{{10,53,10}} },
+        {31,3,{{10,53,11}} },
+        {31,3,{{10,53,12}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,3,4,5,6,7,8},
+      ClothList = {
+        {26,2,{{10,0,0}} },
+        {26,2,{{10,44,6}} },
+        {26,2,{{10,44,7}} },
+        {26,2,{{10,44,8}} },
+        {26,2,{{10,44,9}} },
+        {26,2,{{10,44,10}} },
+        {26,2,{{10,43,0}} },
+        {26,2,{{10,42,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,3,4,5,6,7,8},
+      ClothList = {
+        {28,2,{{10,0,0}} },
+        {28,2,{{10,52,6}} },
+        {28,2,{{10,52,7}} },
+        {28,2,{{10,52,8}} },
+        {28,2,{{10,52,9}} },
+        {28,2,{{10,52,10}} },
+        {28,2,{{10,51,0}} },
+        {28,2,{{10,50,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B Collar",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,3,4,5,6,7,8},
+      ClothList = {
+        {28,2,{{10,0,0}} },
+        {28,2,{{10,44,6}} },
+        {28,2,{{10,44,7}} },
+        {28,2,{{10,44,8}} },
+        {28,2,{{10,44,9}} },
+        {28,2,{{10,44,10}} },
+        {28,2,{{10,43,0}} },
+        {28,2,{{10,42,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,3,4,5,6,7,8},
+      ClothList = {
+        {30,2,{{10,0,0}} },
+        {30,2,{{10,52,6}} },
+        {30,2,{{10,52,7}} },
+        {30,2,{{10,52,8}} },
+        {30,2,{{10,52,9}} },
+        {30,2,{{10,52,10}} },
+        {30,2,{{10,51,0}} },
+        {30,2,{{10,50,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 9,
+    Category = "Undershirt",
+    CategoryIndex = 1,
+    Name = "Class B CVE",
+    Male = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,3,4,5,6,7,8},
+      ClothList = {
+        {28,3,{{10,0,0}} },
+        {28,3,{{10,44,6}} },
+        {28,3,{{10,44,7}} },
+        {28,3,{{10,44,8}} },
+        {28,3,{{10,44,9}} },
+        {28,3,{{10,44,10}} },
+        {28,3,{{10,43,0}} },
+        {28,3,{{10,42,0}} },
+      }
+    },
+    Female = {
+      Ranked = true,
+      RankList = {1,1,1,1,2,3,4,5,6,7,8},
+      ClothList = {
+        {30,3,{{10,0,0}} },
+        {30,3,{{10,52,6}} },
+        {30,3,{{10,52,7}} },
+        {30,3,{{10,52,8}} },
+        {30,3,{{10,52,9}} },
+        {30,3,{{10,52,10}} },
+        {30,3,{{10,51,0}} },
+        {30,3,{{10,50,0}} },
+      }
+    },
   },
 }

--- a/Config/Wardrobes/Files/SWAT/AccessoiresEUP.lua
+++ b/Config/Wardrobes/Files/SWAT/AccessoiresEUP.lua
@@ -9,48 +9,6 @@ SWATAccessoires = {
       Ranked = false,
       RankList = {},
       ClothList = {
-        {59,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {59,0,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 0,
-    Name = "SWAT",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {59,1,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {59,1,{} },
-      }
-    },
-  },
-  {
-    Type = 1,
-    ComponentID = 0,
-    Category = "Helmet",
-    CategoryIndex = 0,
-    Name = "SWAT",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
         {75,0,{} },
       }
     },
@@ -80,27 +38,6 @@ SWATAccessoires = {
       RankList = {},
       ClothList = {
         {74,1,{} },
-      }
-    },
-  },
-  {
-    Type = 0,
-    ComponentID = 10,
-    Category = "Sticker",
-    CategoryIndex = 0,
-    Name = "LS SWAT",
-    Male = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {3,0,{} },
-      }
-    },
-    Female = {
-      Ranked = false,
-      RankList = {},
-      ClothList = {
-        {4,0,{} },
       }
     },
   },

--- a/Config/Wardrobes/Files/SWAT/LegsEUP.lua
+++ b/Config/Wardrobes/Files/SWAT/LegsEUP.lua
@@ -1,3 +1,65 @@
 SWATLegs = {
-  
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Combat Uniform",
+    CategoryIndex = 3,
+    Name = "LSPD",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {31,0,{{6,51,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {31,0,{{6,101,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Combat Uniform",
+    CategoryIndex = 3,
+    Name = "LSSD",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {31,1,{{6,51,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {31,1,{{6,101,0}} },
+      }
+    },
+  },
+  {
+    Type = 0,
+    ComponentID = 4,
+    Category = "Combat Uniform",
+    CategoryIndex = 3,
+    Name = "Standard Issue",
+    Male = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {31,2,{{6,51,0}} },
+      }
+    },
+    Female = {
+      Ranked = false,
+      RankList = {},
+      ClothList = {
+        {31,2,{{6,101,0}} },
+      }
+    },
+  },
 }

--- a/Config/Wardrobes/Files/SWAT/TopsEUP.lua
+++ b/Config/Wardrobes/Files/SWAT/TopsEUP.lua
@@ -4,7 +4,7 @@ SWATTops = {
     ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
     Category = "T-Shirt", -- the item will be categorized inside this category
     CategoryIndex = 0,
-    Name = "LSPD SWAT", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Name = "LSPD", -- the item will bear this name. If multiple options have the same name, you can choose different designs
     Male = {
       Ranked = false, -- defines if the clothing has rank insignia
       ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
@@ -20,5 +20,180 @@ SWATTops = {
       RankList = {},
     },
 
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Riot", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Class B LSPD", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {150, 8, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {147, 8, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T0", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "LSPD", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {220, 0, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {230, 0, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T0", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "LSSD", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {220, 1, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {230, 1, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T0", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "LSSD", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {220, 2, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {230, 2, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T0", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "Black", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {220, 4, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {230, 4, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T0", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "SAHP", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {220, 7, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {230, 7, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+  },
+  {
+    Type = 0, -- 0: component, 1: prop
+    ComponentID = 11, -- =component-ID in the FiveM-native SetPedComponentVariation
+    Category = "Jacket T0", -- the item will be categorized inside this category
+    CategoryIndex = 0,
+    Name = "SAPR", -- the item will bear this name. If multiple options have the same name, you can choose different designs
+    Male = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {220, 25, {{3,4,0},{5,0,0},{8,15,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
+    Female = {
+      Ranked = false, -- defines if the clothing has rank insignia
+      ClothList = { -- if "Ranked" is false only put in one option! If "Ranked" is set to true, you can fill this with multiple options.
+        {230, 25, {{3,3,0},{5,0,0},{8,14,0},{9,0,0},{10,0,0}} },
+      },
+      RankList = {
+
+      },
+    },
   },
 }

--- a/Config/config_cl.lua
+++ b/Config/config_cl.lua
@@ -17,6 +17,9 @@ ActivateGarages = true -- activates garages in general. If set to false no garag
 ActivateWeaponMarkers = true -- activates the armory.
 ActivateEvidenceMarkers = true -- activates the evidence markers. Should stay activated.
 ActivateHelpMarkers = true -- activates the help markers.
+ActivateRepairMarkers = true
+ActivateDeleteMarkers = true -- activates Car Impound / Deletion Markers
+ActivateTPMarkers = true -- activates Teleportation Markers (alternative way to use the tp-command only in stations)
 
 -- service variables
 TowTruckDrivers = {"cs_floyd", "mp_f_bennymech_01", "mp_m_waremech_01", "s_m_m_autoshop_02", "s_m_m_dockwork_01", "s_m_m_gardener_01", "s_m_y_construct_02", "s_m_y_garbage", "s_m_y_winclean_01", "s_m_y_xmech_01"}
@@ -414,6 +417,38 @@ var_weap_swat_textdict = nil
 var_weap_swat_textname = nil
 var_weap_swat_drawonent = false
 
+var_weap_dpos_symbol = 21
+var_weap_dpos_scaleY = 1.0
+var_weap_dpos_scaleX = 1.0
+var_weap_dpos_scaleZ = 1.0
+var_weap_dpos_red = 255
+var_weap_dpos_green = 150
+var_weap_dpos_blue = 0
+var_weap_dpos_alpha = 200
+var_weap_dpos_bob = false
+var_weap_dpos_face = false
+var_weap_dpos_p19 = 2
+var_weap_dpos_rotate = true
+var_weap_dpos_textdict = nil
+var_weap_dpos_textname = nil
+var_weap_dpos_drawonent = false
+
+var_weap_fire_symbol = 21
+var_weap_fire_scaleY = 1.0
+var_weap_fire_scaleX = 1.0
+var_weap_fire_scaleZ = 1.0
+var_weap_fire_red = 255
+var_weap_fire_green = 0
+var_weap_fire_blue = 0
+var_weap_fire_alpha = 200
+var_weap_fire_bob = false
+var_weap_fire_face = false
+var_weap_fire_p19 = 2
+var_weap_fire_rotate = true
+var_weap_fire_textdict = nil
+var_weap_fire_textname = nil
+var_weap_fire_drawonent = false
+
 -- -- Evidence
 var_evidence_symbol = 29
 var_evidence_scaleX = 0.6
@@ -447,3 +482,54 @@ var_tut_rotate = true
 var_tut_textdict = nil
 var_tut_textname = nil
 var_tut_drawonent = false
+
+-- -- Repair
+var_repair_symbol = 22
+var_repair_scaleX = 2.3
+var_repair_scaleY = 2.3
+var_repair_scaleZ = 2.3
+var_repair_red = 255
+var_repair_green = 150
+var_repair_blue = 0
+var_repair_alpha = 200
+var_repair_bob = false
+var_repair_face = false
+var_repair_p19 = 2
+var_repair_rotate = true
+var_repair_textdict = nil
+var_repair_textname = nil
+var_repair_drawonent = false
+
+-- -- Vehicle Impound
+var_impound_symbol = 30
+var_impound_scaleX = 1.5
+var_impound_scaleY = 1.5
+var_impound_scaleZ = 1.5
+var_impound_red = 255
+var_impound_green = 150
+var_impound_blue = 0
+var_impound_alpha = 200
+var_impound_bob = false
+var_impound_face = true
+var_impound_p19 = 2
+var_impound_rotate = false
+var_impound_textdict = nil
+var_impound_textname = nil
+var_impound_drawonent = false
+
+-- -- TP
+var_tp_symbol = 1
+var_tp_scaleX = 2.0
+var_tp_scaleY = 2.0
+var_tp_scaleZ = 3.0
+var_tp_red = 45
+var_tp_green = 38
+var_tp_blue = 106
+var_tp_alpha = 100
+var_tp_bob = false
+var_tp_face = false
+var_tp_p19 = 2
+var_tp_rotate = false
+var_tp_textdict = nil
+var_tp_textname = nil
+var_tp_drawonent = false

--- a/Database/NoDB_cl.lua
+++ b/Database/NoDB_cl.lua
@@ -1,0 +1,68 @@
+local database_enabled = false
+
+DBPlayerData = {}
+DBCharacterData = {}
+DBWardrobeData = {}
+
+DBWardrobeMenuData = {
+  ListOfOutfitNames = {
+    [1] = {
+      lspd = {
+
+      },
+      bcso = {
+
+      },
+      sasp = {
+
+      },
+      sapr = {
+
+      },
+      swat = {
+
+      },
+      fire = {
+
+      },
+      dpos = {
+
+      },
+    },
+    [2] = {
+      lspd = {
+
+      },
+      bcso = {
+
+      },
+      sasp = {
+
+      },
+      sapr = {
+
+      },
+      swat = {
+
+      },
+      fire = {
+
+      },
+      dpos = {
+
+      },
+    },
+  },
+}
+
+AddEventHandler('pd5m:db:SaveCurrentOutfit', function()
+  Notify('Database is disabled. Action not possible.')
+end)
+
+AddEventHandler('pd5m:db:LoadOutfit', function()
+  Notify('Database is disabled. Action not possible.')
+end)
+
+AddEventHandler('pd5m:db:DeleteOutfit', function()
+  Notify('Database is disabled. Action not possible.')
+end)

--- a/Database/NoDB_sv.lua
+++ b/Database/NoDB_sv.lua
@@ -1,0 +1,1 @@
+local database_enabled = false

--- a/Database/database_cl.lua
+++ b/Database/database_cl.lua
@@ -1,0 +1,351 @@
+local database_enabled = true
+
+DBPlayerData = {}
+DBCharacterData = {}
+DBWardrobeData = {}
+
+DBWardrobeMenuData = {
+  ListOfOutfitNames = {
+    [1] = {
+      lspd = {
+
+      },
+      bcso = {
+
+      },
+      sasp = {
+
+      },
+      sapr = {
+
+      },
+      swat = {
+
+      },
+      lsfd = {
+
+      },
+      bcfd = {
+
+      },
+      dpos = {
+
+      },
+    },
+    [2] = {
+      lspd = {
+
+      },
+      bcso = {
+
+      },
+      sasp = {
+
+      },
+      sapr = {
+
+      },
+      swat = {
+
+      },
+      lsfd = {
+
+      },
+      bcfd = {
+
+      },
+      dpos = {
+
+      },
+    },
+  },
+}
+
+RegisterNetEvent('pd5m:db:RecieveData')
+AddEventHandler('pd5m:db:RecieveData', function(PlData, ChData, ClData)
+  DBPlayerData = Pldata
+  DBCharacterData = ChData
+  DBWardrobeData = ClData
+
+  TriggerEvent('pd5m:db:RecreateWardrobeMenuData')
+end)
+
+AddEventHandler('pd5m:db:RecreateWardrobeMenuData', function()
+  local lspdMExists = false
+  local bcsoMExists = false
+  local saspMExists = false
+  local saprMExists = false
+  local swatMExists = false
+  local lsfdMExists = false
+  local bcfdMExists = false
+  local dposMExists = false
+  local lspdFExists = false
+  local bcsoFExists = false
+  local saspFExists = false
+  local saprFExists = false
+  local swatFExists = false
+  local lsfdFExists = false
+  local bcfdFExists = false
+  local dposFExists = false
+
+
+  DBWardrobeMenuData = {
+    ListOfOutfitNames = {
+      [1] = {
+        lspd = {
+
+        },
+        bcso = {
+
+        },
+        sasp = {
+
+        },
+        sapr = {
+
+        },
+        swat = {
+
+        },
+        lsfd = {
+
+        },
+        bcfd = {
+
+        },
+        dpos = {
+
+        },
+      },
+      [2] = {
+        lspd = {
+
+        },
+        bcso = {
+
+        },
+        sasp = {
+
+        },
+        sapr = {
+
+        },
+        swat = {
+
+        },
+        lsfd = {
+
+        },
+        bcfd = {
+
+        },
+        dpos = {
+
+        },
+      },
+    },
+  }
+  for name, entry in pairs(DBWardrobeData) do
+    local PedGender = entry.Gender
+    local Department = entry.Department
+    if Department == 'lspd' then
+      if PedGender == 1 then
+        lspdMExists = true
+      else
+        lspdFExists = true
+      end
+    elseif Department == 'bcso' then
+      if PedGender == 1 then
+        bcsoMExists = true
+      else
+        bcsoFExists = true
+      end
+    elseif Department == 'sasp' then
+      if PedGender == 1 then
+        saspMExists = true
+      else
+        saspFExists = true
+      end
+    elseif Department == 'sapr' then
+      if PedGender == 1 then
+        saprMExists = true
+      else
+        saprFExists = true
+      end
+    elseif Department == 'swat' then
+      if PedGender == 1 then
+        swatMExists = true
+      else
+        swatFExists = true
+      end
+    elseif Department == 'lsfd' then
+      if PedGender == 1 then
+        lsfdMExists = true
+      else
+        lsfdFExists = true
+      end
+    elseif Department == 'bcfd' then
+      if PedGender == 1 then
+        bcfdMExists = true
+      else
+        bcfdFExists = true
+      end
+    elseif Department == 'dpos' then
+      if PedGender == 1 then
+        dposMExists = true
+      else
+        dposFExists = true
+      end
+    end
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[PedGender][Department], name)
+  end
+
+  if not lspdMExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[1].lspd, 'No Outfit available')
+  end
+  if not lspdFExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[2].lspd, 'No Outfit available')
+  end
+  if not bcsoMExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[1].bcso, 'No Outfit available')
+  end
+  if not bcsoFExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[2].bcso, 'No Outfit available')
+  end
+  if not saspMExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[1].sasp, 'No Outfit available')
+  end
+  if not saspFExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[2].sasp, 'No Outfit available')
+  end
+  if not saprMExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[1].sapr, 'No Outfit available')
+  end
+  if not saprFExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[2].sapr, 'No Outfit available')
+  end
+  if not swatMExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[1].swat, 'No Outfit available')
+  end
+  if not swatFExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[2].swat, 'No Outfit available')
+  end
+  if not lsfdMExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[1].lsfd, 'No Outfit available')
+  end
+  if not lsfdFExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[2].lsfd, 'No Outfit available')
+  end
+  if not bcfdMExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[1].bcfd, 'No Outfit available')
+  end
+  if not bcfdFExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[2].bcfd, 'No Outfit available')
+  end
+  if not dposMExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[1].dpos, 'No Outfit available')
+  end
+  if not dposFExists then
+    table.insert(DBWardrobeMenuData.ListOfOutfitNames[2].dpos, 'No Outfit available')
+  end
+
+end)
+
+AddEventHandler('pd5m:db:SaveCurrentOutfit', function(Department, PedGender)
+  AddTextEntry('SaveOutfitLabel', 'Enter Outfit Name (Use Numbers, Letters, _ and : )')
+  DisplayOnscreenKeyboard(6, "SaveOutfitLabel", "lspd_m_Lieutenant1", "", "", "", "", 30)
+  while (UpdateOnscreenKeyboard() == 0) do
+    DisableAllControlActions(0)
+    Wait(0)
+  end
+  if (GetOnscreenKeyboardResult()) then
+    local result = GetOnscreenKeyboardResult()
+    if result ~= nil then
+      local ResultValid = true
+      for i=1,string.len(result),1 do
+        local c = string.sub(result, i, i)
+        if not ( string.match(c, "%a") or string.match(c, "%d") or string.match(c, "[:_]") ) then
+          ResultValid = false
+          break
+        end
+      end
+
+      if ResultValid then
+        local ResultUnique = true
+        for name, entry in pairs(DBWardrobeData) do
+          if name == result then
+            ResultUnique = false
+            break
+          end
+        end
+        if ResultUnique then
+          local playerped = GetPlayerPed(-1)
+          local ClothTable = {
+            Department = Department,
+            Gender = PedGender,
+            Components = {
+              {1,GetPedDrawableVariation(playerped, 1), GetPedTextureVariation(playerped, 1), GetPedPaletteVariation(playerped, 1)},
+              {3,GetPedDrawableVariation(playerped, 3), GetPedTextureVariation(playerped, 3), GetPedPaletteVariation(playerped, 3)},
+              {4,GetPedDrawableVariation(playerped, 4), GetPedTextureVariation(playerped, 4), GetPedPaletteVariation(playerped, 4)},
+              {5,GetPedDrawableVariation(playerped, 5), GetPedTextureVariation(playerped, 5), GetPedPaletteVariation(playerped, 5)},
+              {6,GetPedDrawableVariation(playerped, 6), GetPedTextureVariation(playerped, 6), GetPedPaletteVariation(playerped, 6)},
+              {7,GetPedDrawableVariation(playerped, 7), GetPedTextureVariation(playerped, 7), GetPedPaletteVariation(playerped, 7)},
+              {8,GetPedDrawableVariation(playerped, 8), GetPedTextureVariation(playerped, 8), GetPedPaletteVariation(playerped, 8)},
+              {9,GetPedDrawableVariation(playerped, 9), GetPedTextureVariation(playerped, 9), GetPedPaletteVariation(playerped, 9)},
+              {10,GetPedDrawableVariation(playerped, 10), GetPedTextureVariation(playerped, 10), GetPedPaletteVariation(playerped, 10)},
+              {11,GetPedDrawableVariation(playerped, 11), GetPedTextureVariation(playerped, 11), GetPedPaletteVariation(playerped, 11)},
+            },
+            Props = {
+              {0, GetPedPropIndex(playerped, 0), GetPedPropTextureIndex(playerped, 0)},
+              {1, GetPedPropIndex(playerped, 1), GetPedPropTextureIndex(playerped, 1)},
+              {2, GetPedPropIndex(playerped, 2), GetPedPropTextureIndex(playerped, 2)},
+              {6, GetPedPropIndex(playerped, 6), GetPedPropTextureIndex(playerped, 6)},
+              {7, GetPedPropIndex(playerped, 7), GetPedPropTextureIndex(playerped, 7)},
+            },
+          }
+
+          TriggerServerEvent('pd5m:dbsv:RecieveData', 'Clothing', 'AddItem', result, ClothTable)
+          Notify('Outfit saved successfully with name ~g~' .. result .. '~s~.')
+        else
+          Notify('Name already chosen in your wardrobe.')
+        end
+      else
+        Notify('Please enter a valid name.')
+      end
+    else
+      Notify('Please enter a valid name.')
+    end
+  else
+    Notify('Please enter a valid name.')
+  end
+end)
+
+AddEventHandler('pd5m:db:LoadOutfit', function(name)
+  if name == 'No Outfit available' then
+    Notify('Cannot load any outfit.')
+  else
+    Notify('Loading outfit ~g~' .. name .. "~s~.")
+    local playerped = GetPlayerPed(-1)
+    local Components = DBWardrobeData[name].Components
+    local Props = DBWardrobeData[name].Props
+
+    for i, comp in ipairs(Components) do
+      SetPedComponentVariation(playerped, comp[1], comp[2], comp[3], comp[4])
+    end
+    for i, prop in ipairs(Props) do
+      if prop[2] == -1 then
+        ClearPedProp(playerped, prop[1])
+      else
+        SetPedPropIndex(playerped, prop[1], prop[2], prop[3], true)
+      end
+    end
+  end
+end)
+
+AddEventHandler('pd5m:db:DeleteOutfit', function(name)
+  if name == 'No Outfit available' then
+    Notify('Cannot delete any outfit.')
+  else
+    TriggerServerEvent('pd5m:dbsv:RecieveData', 'Clothing', 'DeleteItem', name, {})
+  end
+end)

--- a/Database/database_sv.lua
+++ b/Database/database_sv.lua
@@ -1,0 +1,152 @@
+local database_enabled = true
+local integer = 0
+
+RegisterNetEvent('pd5m:dbsv:CheckMainDatabaseExists')
+AddEventHandler('pd5m:dbsv:CheckMainDatabaseExists', function()
+  local main = LoadResourceFile('pd5m', 'Database/DatabaseFiles/Main.json')
+  if main then
+    print('Database loaded successfully')
+    data = json_GetFile('Main')
+    CreateThread(function()
+      local foundFreeId = false
+      while not foundFreeId do
+        integer = integer + 1
+        if data[integer] == nil then
+          break
+        end
+        Wait(0)
+      end
+      print('Next database ID', integer)
+    end)
+  else
+    print('Creating Database')
+    TriggerEvent('pd5m:dbsv:CreateMainDatabaseFiles')
+  end
+end)
+
+AddEventHandler('pd5m:dbsv:CreateMainDatabaseFiles', function()
+  local MainFile = io.open(GetResourcePath('pd5m') .. "/Database/DatabaseFiles/Main.json", "w")
+  MainFile:write("{}")
+  MainFile:close()
+  integer = 1
+end)
+
+RegisterNetEvent('pd5m:dbsv:PlayerConnected')
+AddEventHandler('pd5m:dbsv:PlayerConnected', function()
+  local id = source
+  local LoadedData, DbId = pd5m_dbsv_FindPlayerDatabaseId(id)
+  if not LoadedData then
+    print('Creating Data')
+    TriggerEvent('pd5m:dbsv:CreateNewPlayer', id)
+  else
+    print('Loaded Data')
+    TriggerEvent('pd5m:dbsv:LoadPlayer', id, DbId)
+  end
+end)
+
+AddEventHandler('pd5m:dbsv:CreateNewPlayer', function(id)
+  local xdbid = integer
+  integer = integer + 1
+  local xsteamid, xlicense, xdiscord, xfivem = pd5m_dbsv_ReturnEventHandlers(id)
+  local Content = {
+    dbid = xdbid,
+    steamid = xsteamid,
+    license = xlicense,
+    discord = xdiscord,
+    fivem = xfivem,
+  }
+  local dbid = xdbid
+  json_AddItem('Main', dbid, Content)
+
+  local CharsFile = io.open(GetResourcePath('pd5m') .. "/Database/DatabaseFiles/Characters/" .. tostring(dbid) .. ".json", "w")
+  CharsFile:write("{}")
+  CharsFile:close()
+
+  local PlsFile = io.open(GetResourcePath('pd5m') .. "/Database/DatabaseFiles/Players/" .. tostring(dbid) .. ".json", "w")
+  PlsFile:write("{}")
+  PlsFile:close()
+
+  local ClothsFile = io.open(GetResourcePath('pd5m') .. "/Database/DatabaseFiles/Wardrobes/" .. tostring(dbid) .. ".json", "w")
+  ClothsFile:write("{}")
+  ClothsFile:close()
+
+  TriggerClientEvent('pd5m:db:RecieveData', id, {}, {}, {})
+end)
+
+AddEventHandler('pd5m:dbsv:LoadPlayer', function(id, dbid)
+
+  local PlData = json_GetFile("Players/" .. tostring(dbid))
+  local ChData = json_GetFile("Characters/" .. tostring(dbid))
+  local ClData = json_GetFile("Wardrobes/" .. tostring(dbid))
+
+  TriggerClientEvent('pd5m:db:RecieveData', id, PlData, ChData, ClData)
+end)
+
+RegisterNetEvent('pd5m:dbsv:RecieveData')
+AddEventHandler('pd5m:dbsv:RecieveData', function(type, task, name, value)
+  local id = source
+  local LoadedData, DbId = pd5m_dbsv_FindPlayerDatabaseId(id)
+  if LoadedData then
+    local PathPrefix = nil
+    if type == 'Player' then
+      PathPrefix = 'Players/'
+    elseif type == 'Character' then
+      PathPrefix = 'Characters/'
+    elseif type == 'Clothing' then
+      PathPrefix = 'Wardrobes/'
+    end
+
+    if task == 'AddItem' then
+      json_AddItem(PathPrefix .. tostring(DbId), name, value)
+    elseif task == 'DeleteItem' then
+      json_DeleteItem(PathPrefix .. tostring(DbId), name)
+    elseif task == 'ReplaceItem' then
+      json_ReplaceItem(PathPrefix .. tostring(DbId), name, value)
+    end
+
+    local PlData = json_GetFile("Players/" .. tostring(DbId))
+    local ChData = json_GetFile("Characters/" .. tostring(DbId))
+    local ClData = json_GetFile("Wardrobes/" .. tostring(DbId))
+
+    TriggerClientEvent('pd5m:db:RecieveData', id, PlData, ChData, ClData)
+
+  else
+    print('Tried loading data of type ' .. type .. ' with task ' .. task .. ". Didn't find player database ID." )
+  end
+end)
+
+function pd5m_dbsv_ReturnEventHandlers(id)
+  local steamid = false
+  local license = false
+  local discord = false
+  local fivem = false
+
+  for i, id in pairs(GetPlayerIdentifiers(id)) do
+    if string.sub(id, 1, string.len("steam:")) == "steam:" then
+      steamid = id
+    elseif string.sub(id, 1, string.len("license:")) == "license:" then
+      license = id
+    elseif string.sub(id, 1, string.len("discord:")) == "discord:" then
+      discord = id
+    elseif string.sub(id, 1, string.len("fivem:")) == "fivem:" then
+      fivem = id
+    end
+  end
+
+  return steamid, license, discord, fivem
+end
+
+function pd5m_dbsv_FindPlayerDatabaseId(id)
+  local bool = false
+  local dbid = 0
+  local steamid, license, discord, fivem = pd5m_dbsv_ReturnEventHandlers(id)
+  local MainData = json_GetFile('Main')
+  for i, entry in pairs(MainData) do
+    if (steamid == entry.steamid and not steamid == false) or (license == entry.license and not license == false) or (discord == entry.discord and not discord == false) or (fivem == entry.fivem and not fivem == false) then
+      bool = true
+      dbid = i
+      break
+    end
+  end
+  return bool, dbid
+end

--- a/Database/jsonhandler_sv.lua
+++ b/Database/jsonhandler_sv.lua
@@ -1,0 +1,136 @@
+local resource_name = GetCurrentResourceName()
+
+function json_GetFile(filename)
+    local loaded_data = LoadResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json")
+    local file_data = json.decode(loaded_data or '{}')
+    return file_data
+end
+
+function json_GetItem(filename, itemname)
+    local loaded_data = LoadResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json")
+    local file_data = json.decode(loaded_data or "{}")
+    return file_data[itemname]
+end
+
+function json_AddItem(filename, itemname, itemcontent)
+    local loaded_data = LoadResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json")
+    local file_data = json.decode(loaded_data or '{}')
+    file_data[itemname] = itemcontent
+    SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json", json.encode(file_data, { indent = true }), -1)
+end
+
+function json_DeleteItem(filename, itemname)
+    local loaded_data = LoadResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json")
+    local file_data = json.decode(loaded_data or '{}')
+    if file_data[itemname] ~= nil then
+        file_data[itemname] = nil
+        SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json", json.encode(file_data, { indent = true }), -1)
+    else
+        print("^1[ERROR][" .. resource_name .. "]^7 Attempted to delete a non-existing item.")
+        return
+    end
+end
+
+function json_ReplaceItem(filename, itemname, itemcontent)
+    local loaded_data = LoadResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json")
+    local file_data = json.decode(loaded_data or '{}')
+    if file_data[itemname] ~= nil then
+        file_data[itemname] = itemcontent
+        SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json", json.encode(file_data, { indent = true }), -1)
+    else
+        print("^1[ERROR][" .. resource_name .. "]^7 Attempted to replace a non-existing item.")
+        return
+    end
+end
+
+function json_ReplaceData(filename, itemname, table)
+    local loaded_data = LoadResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json")
+    local file_data = json.decode(loaded_data or '{}')
+    for k, v in ipairs(table) do
+        local name = table[k].name
+        local value = table[k].content
+        if file_data[itemname][name] ~= nil then
+            file_data[itemname][name] = value
+            SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json", json.encode(file_data, { indent = true }), -1)
+        else
+            print("^1[ERROR][" .. resource_name .. "]^7 Attempted to replace a non-existing data (^3" .. name .. "^7) within ^3" .. itemname .. "^7 in file ^3" .. filename .. ".json^7")
+        end
+    end
+end
+
+function json_DeleteData(filename, itemname, dataname)
+    local loaded_data = LoadResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json")
+    local file_data = json.decode(loaded_data or '{}')
+    if file_data[itemname][dataname] ~= nil then
+        file_data[itemname][dataname] = nil
+        SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. filename .. ".json", json.encode(file_data, { indent = true }), -1)
+    else
+        print("^1[ERROR][" .. resource_name .. "]^7 Attempted to delete a non-existing data (^3" .. dataname .. "^7) within ^3" .. itemname .. "^7 in file ^3" .. filename .. ".json^7")
+    end
+end
+
+--Combined function
+function json_InitiateFile(filename)
+    local self = {}
+
+    self.filename = filename
+    self.loaded_data = LoadResourceFile(resource_name, "Database/DatabaseFiles/" .. self.filename .. ".json")
+    self.file_data = json.decode(self.loaded_data or "{}")
+
+    self.GetFile = function()
+        return self.file_data
+    end
+
+    self.GetItem = function(itemname)
+        return self.file_data[itemname]
+    end
+
+    self.AddItem = function(itemname, itemcontent)
+        self.file_data[itemname] = itemcontent
+        SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. self.filename .. ".json", json.encode(self.file_data, { indent = true }), -1)
+    end
+
+    self.DeleteItem = function(itemname)
+        if self.file_data[itemname] ~= nil then
+            self.file_data[itemname] = nil
+            SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. self.filename .. ".json", json.encode(self.file_data, { indent = true }), -1)
+        else
+            print("^1[ERROR][" .. resource_name .. "]^7 Attempted to delete a non-existing item.")
+            return
+        end
+    end
+
+    self.ReplaceItem = function(itemname, itemcontent)
+        if self.file_data[itemname] ~= nil then
+            self.file_data[itemname] = itemcontent
+            SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. self.filename .. ".json", json.encode(self.file_data, { indent = true }), -1)
+        else
+            print("^1[ERROR][" .. resource_name .. "]^7 Attempted to replace a non-existing item.")
+            return
+        end
+    end
+
+    self.ReplaceData = function(itemname, table)
+        for k, v in ipairs(table) do
+            local name = table[k].name
+            local value = table[k].content
+            if self.file_data[itemname][name] ~= nil then
+                self.file_data[itemname][name] = value
+                SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. self.filename .. ".json", json.encode(self.file_data, { indent = true }), -1)
+            else
+                print("^1[ERROR][" .. resource_name .. "]^7 Attempted to replace a non-existing data (^3" .. name .. "^7) within ^3" .. itemname .. "^7 in file ^3" .. self.filename .. ".json^7")
+            end
+        end
+    end
+
+    self.DeleteData = function(itemname, dataname)
+        if self.file_data[itemname][dataname] ~= nil then
+            self.file_data[itemname][dataname] = nil
+            SaveResourceFile(resource_name, "Database/DatabaseFiles/" .. self.filename .. ".json", json.encode(self.file_data, { indent = true }), -1)
+        else
+            print("^1[ERROR][" .. resource_name .. "]^7 Attempted to delete a non-existing data (^3" .. dataname .. "^7) within ^3" .. itemname .. "^7 in file ^3" .. self.filename .. ".json^7")
+        end
+    end
+
+    return self
+end

--- a/Duty/ranks_sv.lua
+++ b/Duty/ranks_sv.lua
@@ -1,7 +1,0 @@
-AddEventHandler('chatMessage', function(s, n, m)
-  local message = string.lower(m)
-  if message == "/rank" then
-    CancelEvent()
-    TriggerClientEvent('pd5m:duty:openrankmenu', s)
-  end
-end)

--- a/HUD/markers_cl.lua
+++ b/HUD/markers_cl.lua
@@ -6,6 +6,9 @@ local list_show_cars_coords = {}
 local list_show_weap_coords = {}
 local list_show_evidence_coords = {}
 local list_show_help_coords = {}
+local list_show_repair_coords = {}
+local list_show_delete_coords = {}
+local list_show_tp_coords = {}
 
 CreateThread(function()
 	local range = 40000.0
@@ -38,6 +41,18 @@ CreateThread(function()
 		list_help_coords = {}
 	end
 
+	if not ActivateRepairMarkers then
+		list_repair_coords = {}
+	end
+
+	if not ActivateDeleteMarkers then
+		list_delete_coords = {}
+	end
+
+	if not ActivateTPMarkers then
+		list_tpmarker_coords = {}
+	end
+
 	while true do
 		list_show_arrest_coords = {}
 		list_show_cloth_coords = {}
@@ -46,6 +61,10 @@ CreateThread(function()
 		list_show_weap_coords = {}
 		list_show_evidence_coords = {}
 		list_show_help_coords = {}
+		list_show_repair_coords = {}
+		list_show_delete_coords = {}
+		list_show_tp_coords = {}
+
 		local playerped = GetPlayerPed(-1)
 		local plc = GetEntityCoords(playerped, true)
 		for i, coord in ipairs(list_arrest_coords) do
@@ -81,6 +100,21 @@ CreateThread(function()
 		for i, coord in ipairs(list_help_coords) do
 			if Vdist2(plc.x, plc.y, plc.z, coord.x, coord.y, coord.z) < range then
 				table.insert(list_show_help_coords, coord)
+			end
+		end
+		for i, coord in ipairs(list_repair_coords) do
+			if Vdist2(plc.x, plc.y, plc.z, coord.x, coord.y, coord.z) < range then
+				table.insert(list_show_repair_coords, coord)
+			end
+		end
+		for i, coord in ipairs(list_delete_coords) do
+			if Vdist2(plc.x, plc.y, plc.z, coord.x, coord.y, coord.z) < range then
+				table.insert(list_show_delete_coords, coord)
+			end
+		end
+		for i, coord in ipairs(list_tpmarker_coords) do
+			if Vdist2(plc.x, plc.y, plc.z, coord.x, coord.y, coord.z) < range then
+				table.insert(list_show_tp_coords, coord)
 			end
 		end
 		Wait(5000)
@@ -148,6 +182,10 @@ CreateThread(function()
 				DrawMarker(var_weap_sasp_symbol, coord.x, coord.y, coord.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, var_weap_sasp_scaleX, var_weap_sasp_scaleY, var_weap_sasp_scaleZ, var_weap_sasp_red, var_weap_sasp_green, var_weap_sasp_blue, var_weap_sasp_alpha, var_weap_sasp_bob, var_weap_sasp_face, var_weap_sasp_p19, var_weap_sasp_rotate, var_weap_sasp_textdict, var_weap_sasp_textname, var_weap_sasp_drawonent)
 			elseif list_handles[coord.handle][1].handles[coord.handle].name =='swat' then
 				DrawMarker(var_weap_swat_symbol, coord.x, coord.y, coord.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, var_weap_swat_scaleX, var_weap_swat_scaleY, var_weap_swat_scaleZ, var_weap_swat_red, var_weap_swat_green, var_weap_swat_blue, var_weap_swat_alpha, var_weap_swat_bob, var_weap_swat_face, var_weap_swat_p19, var_weap_swat_rotate, var_weap_swat_textdict, var_weap_swat_textname, var_weap_swat_drawonent)
+			elseif list_handles[coord.handle][1].handles[coord.handle].name =='lsfd' or list_handles[coord.handle][1].handles[coord.handle].name =='bcfd' then
+				DrawMarker(var_weap_fire_symbol, coord.x, coord.y, coord.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, var_weap_fire_scaleX, var_weap_fire_scaleY, var_weap_fire_scaleZ, var_weap_fire_red, var_weap_fire_green, var_weap_fire_blue, var_weap_fire_alpha, var_weap_fire_bob, var_weap_fire_face, var_weap_fire_p19, var_weap_fire_rotate, var_weap_fire_textdict, var_weap_fire_textname, var_weap_fire_drawonent)
+			elseif list_handles[coord.handle][1].handles[coord.handle].name =='dpos' then
+				DrawMarker(var_weap_dpos_symbol, coord.x, coord.y, coord.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, var_weap_dpos_scaleX, var_weap_dpos_scaleY, var_weap_dpos_scaleZ, var_weap_dpos_red, var_weap_dpos_green, var_weap_dpos_blue, var_weap_dpos_alpha, var_weap_dpos_bob, var_weap_dpos_face, var_weap_dpos_p19, var_weap_dpos_rotate, var_weap_dpos_textdict, var_weap_dpos_textname, var_weap_dpos_drawonent)
 			end
 		end
 		for i,coord in ipairs(list_show_evidence_coords) do
@@ -155,6 +193,15 @@ CreateThread(function()
 		end
 		for i,coord in ipairs(list_show_help_coords) do
 			DrawMarker(var_tut_symbol, coord.x, coord.y, coord.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, var_tut_scaleX, var_tut_scaleY, var_tut_scaleZ, var_tut_red, var_tut_green, var_tut_blue, var_tut_alpha, var_tut_bob, var_tut_face, var_tut_p19, var_tut_rotate, var_tut_textdict, var_tut_textname, var_tut_drawonent)
+		end
+		for i,coord in ipairs(list_show_repair_coords) do
+			DrawMarker(var_repair_symbol, coord.x, coord.y, coord.z+0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, var_repair_scaleX, var_repair_scaleY, var_repair_scaleZ, var_repair_red, var_repair_green, var_repair_blue, var_repair_alpha, var_repair_bob, var_repair_face, var_repair_p19, var_repair_rotate, var_repair_textdict, var_repair_textname, var_repair_drawonent)
+		end
+		for i,coord in ipairs(list_show_delete_coords) do
+			DrawMarker(var_impound_symbol, coord.x, coord.y, coord.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, var_impound_scaleX, var_impound_scaleY, var_impound_scaleZ, var_impound_red, var_impound_green, var_impound_blue, var_impound_alpha, var_impound_bob, var_impound_face, var_impound_p19, var_impound_rotate, var_impound_textdict, var_impound_textname, var_impound_drawonent)
+		end
+		for i,coord in ipairs(list_show_tp_coords) do
+			DrawMarker(var_tp_symbol, coord.x, coord.y, coord.z-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, var_tp_scaleX, var_tp_scaleY, var_tp_scaleZ, var_tp_red, var_tp_green, var_tp_blue, var_tp_alpha, var_tp_bob, var_tp_face, var_tp_p19, var_tp_rotate, var_tp_textdict, var_tp_textname, var_tp_drawonent)
 		end
 		Wait(0)
 	end
@@ -173,6 +220,9 @@ clothpolice = nil
 if ActivateClothMarkers then
 	local policeindex = nil
 	local ListWarMenuCloth = {}
+	local RankList = {'No Rank'}
+	local RankCurrentIndex = 1
+	local RankSelectedIndex = 1
 
 	CreateThread(function()
 		while true do
@@ -186,27 +236,35 @@ if ActivateClothMarkers then
 					if clothpolice == 'lspd' then
 						policeindex = 1
 						ListWarMenuCloth = ListLSPDCloth
+						RankList = LSPDRanks
 					elseif clothpolice == 'bcso' then
 						policeindex = 2
 						ListWarMenuCloth = ListBCSOCloth
+						RankList = BCSORanks
 					elseif clothpolice == 'sasp' then
 						policeindex = 3
 						ListWarMenuCloth = ListSASPCloth
+						RankList = SASPRanks
 					elseif clothpolice == 'sapr' then
 						policeindex = 4
 						ListWarMenuCloth = ListSAPRCloth
+						RankList = SAPRRanks
 					elseif clothpolice == 'swat' then
 						policeindex = 5
 						ListWarMenuCloth = ListSWATCloth
+						RankList = SWATRanks
 					elseif clothpolice == 'dpos' then
 						policeindex = 6
 						ListWarMenuCloth = ListDPOSCloth
+						RankList = DPOSRanks
 					elseif clothpolice == 'lsfd' then
 						policeindex = 7
 						ListWarMenuCloth = ListLSFDCloth
+						RankList = LSFDRanks
 					elseif clothpolice == 'bcfd' then
 						policeindex = 8
 						ListWarMenuCloth = ListBCFDCloth
+						RankList = BCFDRanks
 					end
 
 					atcloth = true
@@ -231,6 +289,7 @@ if ActivateClothMarkers then
 
 	CreateThread(function()
 
+		local Department = nil
 		local PedGender = nil
 		local playerped = nil
 
@@ -319,14 +378,6 @@ if ActivateClothMarkers then
 		local ChainOptionSelectedIndex = 1
 		local ChainOptionNameList = {1}
 
-		local BadgeCategoryCurrentIndex = 1
-		local BadgeCategorySelectedIndex = 1
-		local BadgeItemCurrentIndex = 1
-		local BadgeItemSelectedIndex = 1
-		local BadgeOptionCurrentIndex = 1
-		local BadgeOptionSelectedIndex = 1
-		local BadgeOptionNameList = {1}
-
 		local BagCategoryCurrentIndex = 1
 		local BagCategorySelectedIndex = 1
 		local BagItemCurrentIndex = 1
@@ -363,6 +414,12 @@ if ActivateClothMarkers then
 		local BraceletOptionSelectedIndex = 1
 		local BraceletOptionNameList = {1}
 
+		local LoadOutfitCurrentIndex = 1
+		local LoadOutfitSelectedIndex = 1
+
+		local DeleteOutfitCurrentIndex = 1
+		local DeleteOutfitSelectedIndex = 1
+
 		WarMenu.CreateMenu('WardrobeMain', 'Wardrobe')
 		WarMenu.CreateSubMenu('WardrobeStandard', 'WardrobeMain', 'Wardrobe') -- change Shirt, Legs and Shoes (components 11, 4, 6)
 		WarMenu.CreateSubMenu('WardrobeAccessoires', 'WardrobeMain', 'Wardrobe') -- change all props, components 1,3,5,7,10
@@ -371,41 +428,12 @@ if ActivateClothMarkers then
 		WarMenu.CreateSubMenu('WardrobeMisc', 'WardrobeAccessoires', 'Wardrobe') -- Components 5, 7, 10
 		WarMenu.CreateSubMenu('WardrobeUndress', 'WardrobeMain', 'Wardrobe') -- undress options for every item
 		WarMenu.CreateSubMenu('WardrobeUndershirt', 'WardrobeStandard', 'Wardrobe') -- change components 8, 9
-
-
+		WarMenu.CreateSubMenu('WardrobeSavedOutfits', 'WardrobeMain', 'Wardrobe')
+		WarMenu.CreateSubMenu('WardrobeLoadOutfit', 'WardrobeSavedOutfits', 'Wardrobe')
+		WarMenu.CreateSubMenu('WardrobeDeleteOutfit', 'WardrobeSavedOutfits', 'Wardrobe')
 
 		while true do
 			if WarMenu.IsMenuOpened('WardrobeMain') then
-				ClothingCurrentDrawables[1] = GetPedPropIndex(playerped, 0)
-				ClothingCurrentDrawables[2] = GetPedPropIndex(playerped, 1)
-				ClothingCurrentDrawables[3] = GetPedPropIndex(playerped, 2)
-				ClothingCurrentDrawables[4] = GetPedPropIndex(playerped, 6)
-				ClothingCurrentDrawables[5] = GetPedPropIndex(playerped, 7)
-				ClothingCurrentDrawables[6] = GetPedDrawableVariation(playerped, 1)
-				ClothingCurrentDrawables[7] = GetPedDrawableVariation(playerped, 3)
-				ClothingCurrentDrawables[8] = GetPedDrawableVariation(playerped, 4)
-				ClothingCurrentDrawables[9] = GetPedDrawableVariation(playerped, 5)
-				ClothingCurrentDrawables[10] = GetPedDrawableVariation(playerped, 6)
-				ClothingCurrentDrawables[11] = GetPedDrawableVariation(playerped, 7)
-				ClothingCurrentDrawables[12] = GetPedDrawableVariation(playerped, 8)
-				ClothingCurrentDrawables[13] = GetPedDrawableVariation(playerped, 9)
-				ClothingCurrentDrawables[14] = GetPedDrawableVariation(playerped, 10)
-				ClothingCurrentDrawables[15] = GetPedDrawableVariation(playerped, 11)
-				ClothingCurrentTextures[1] = GetPedPropTextureIndex(playerped, 0)
-				ClothingCurrentTextures[2] = GetPedPropTextureIndex(playerped, 1)
-				ClothingCurrentTextures[3] = GetPedPropTextureIndex(playerped, 2)
-				ClothingCurrentTextures[4] = GetPedPropTextureIndex(playerped, 6)
-				ClothingCurrentTextures[5] = GetPedPropTextureIndex(playerped, 7)
-				ClothingCurrentTextures[6] = GetPedTextureVariation(playerped, 1)
-				ClothingCurrentTextures[7] = GetPedTextureVariation(playerped, 3)
-				ClothingCurrentTextures[8] = GetPedTextureVariation(playerped, 4)
-				ClothingCurrentTextures[9] = GetPedTextureVariation(playerped, 5)
-				ClothingCurrentTextures[10] = GetPedTextureVariation(playerped, 6)
-				ClothingCurrentTextures[11] = GetPedTextureVariation(playerped, 7)
-				ClothingCurrentTextures[12] = GetPedTextureVariation(playerped, 8)
-				ClothingCurrentTextures[13] = GetPedTextureVariation(playerped, 9)
-				ClothingCurrentTextures[14] = GetPedTextureVariation(playerped, 10)
-				ClothingCurrentTextures[15] = GetPedTextureVariation(playerped, 11)
 				if WarMenu.MenuButton('Uniform', 'WardrobeStandard') then
 					TopCategoryCurrentIndex = 1
 					TopCategorySelectedIndex = 1
@@ -434,15 +462,24 @@ if ActivateClothMarkers then
 					SetPedComponentVariation(playerped, 5, 0, 0, 0)
 					SetPedComponentVariation(playerped, 7, 0, 0, 0)
 					SetPedComponentVariation(playerped, 10, 0, 0, 0)
+					ClearAllPedProps(playerped)
 
 				elseif WarMenu.MenuButton('Accessoires', 'WardrobeAccessoires') then
 				elseif WarMenu.MenuButton('Undress', 'WardrobeUndress') then
+				elseif WarMenu.MenuButton('Saved Outfits', 'WardrobeSavedOutfits') then
 				elseif WarMenu.Button('Exit Menu') then
 					WarMenu.CloseMenu()
 				end
 				WarMenu.Display()
 			elseif WarMenu.IsMenuOpened('WardrobeStandard') then
-				if WarMenu.ComboBox('Top Category', ListWarMenuCloth[1][11].Categories, TopCategoryCurrentIndex, TopCategorySelectedIndex, function(currentIndex, selectedIndex)
+				if WarMenu.ComboBox("Ranks", RankList, RankCurrentIndex, RankSelectedIndex, function(currentIndex, selectedIndex)
+						RankCurrentIndex = currentIndex
+						selectedIndex = currentIndex
+						RankSelectedIndex = selectedIndex
+						PlayerRanks[policeindex] = RankSelectedIndex
+					end) then
+
+				elseif WarMenu.ComboBox('Top Category', ListWarMenuCloth[1][11].Categories, TopCategoryCurrentIndex, TopCategorySelectedIndex, function(currentIndex, selectedIndex)
 						TopCategoryCurrentIndex = currentIndex
 						if currentIndex ~= selectedIndex then
 							TopItemCurrentIndex = 1
@@ -788,14 +825,6 @@ if ActivateClothMarkers then
 					ChainOptionCurrentIndex = 1
 					ChainOptionSelectedIndex = 1
 					ChainOptionNameList = {1}
-
-					BadgeCategoryCurrentIndex = 1
-					BadgeCategorySelectedIndex = 1
-					BadgeItemCurrentIndex = 1
-					BadgeItemSelectedIndex = 1
-					BadgeOptionCurrentIndex = 1
-					BadgeOptionSelectedIndex = 1
-					BadgeOptionNameList = {1}
 
 					BagCategoryCurrentIndex = 1
 					BagCategorySelectedIndex = 1
@@ -1162,51 +1191,7 @@ if ActivateClothMarkers then
 						end
 					end) then
 
-				elseif WarMenu.ComboBox('Extra 4 Category', ListWarMenuCloth[1][10].Categories, BadgeCategoryCurrentIndex, BadgeCategorySelectedIndex, function(currentIndex, selectedIndex)
-						BadgeCategoryCurrentIndex = currentIndex
-						if currentIndex ~= selectedIndex then
-							BadgeItemCurrentIndex = 1
-							BadgeItemSelectedIndex = 1
-							BadgeOptionCurrentIndex = 1
-							BadgeOptionSelectedIndex = 1
-							BadgeOptionNameList = {1}
-						end
-						selectedIndex = currentIndex
-						BadgeCategorySelectedIndex = selectedIndex
-						BadgeCategory = ListWarMenuCloth[1][10].CategoryIndex[BadgeCategorySelectedIndex]
-					end) then
-
-				elseif WarMenu.ComboBox('Extra 4 Item', ListWarMenuCloth[1][10].Items[BadgeCategorySelectedIndex], BadgeItemCurrentIndex, BadgeItemSelectedIndex, function(currentIndex, selectedIndex)
-						BadgeItemCurrentIndex = currentIndex
-						if currentIndex ~= selectedIndex then
-							BadgeOptionCurrentIndex = 1
-							BadgeOptionSelectedIndex = 1
-							BadgeOptionNameList = {1}
-						end
-						selectedIndex = currentIndex
-						BadgeItemSelectedIndex = selectedIndex
-						local BadgeOptionNameListNew = {}
-						for i, list in ipairs(ListWarMenuCloth[1][10].Options[BadgeCategorySelectedIndex][BadgeItemSelectedIndex]) do
-							table.insert(BadgeOptionNameListNew, i)
-						end
-						BadgeOptionNameList = BadgeOptionNameListNew
-					end) then
-
-				elseif WarMenu.ComboBox('Extra 4 Option', BadgeOptionNameList, BadgeOptionCurrentIndex, BadgeOptionSelectedIndex, function(currentIndex, selectedIndex)
-						BadgeOptionCurrentIndex = currentIndex
-						selectedIndex = currentIndex
-						BadgeOptionSelectedIndex = selectedIndex
-						local ClothIndex = 1
-						if ListWarMenuCloth[1][10].Options[BadgeCategorySelectedIndex][BadgeItemSelectedIndex][BadgeOptionSelectedIndex][PedGender].Ranked == true then
-							ClothIndex = ListWarMenuCloth[1][10].Options[BadgeCategorySelectedIndex][BadgeItemSelectedIndex][BadgeOptionSelectedIndex][PedGender].RankList[PlayerRanks[policeindex]]
-						end
-						SetPedComponentVariation(playerped, 10, ListWarMenuCloth[1][10].Options[BadgeCategorySelectedIndex][BadgeItemSelectedIndex][BadgeOptionSelectedIndex][PedGender].ClothList[ClothIndex][1], ListWarMenuCloth[1][10].Options[BadgeCategorySelectedIndex][BadgeItemSelectedIndex][BadgeOptionSelectedIndex][PedGender].ClothList[ClothIndex][2], 0)
-						for i, List in ipairs(ListWarMenuCloth[1][10].Options[BadgeCategorySelectedIndex][BadgeItemSelectedIndex][BadgeOptionSelectedIndex][PedGender].ClothList[ClothIndex][3]) do
-							SetPedComponentVariation(playerped, List[1], List[2], List[3], 0)
-						end
-					end) then
-
-				elseif WarMenu.ComboBox('Extra 5 Category', ListWarMenuCloth[1][5].Categories, BagCategoryCurrentIndex, BagCategorySelectedIndex, function(currentIndex, selectedIndex)
+				elseif WarMenu.ComboBox('Extra 4 Category', ListWarMenuCloth[1][5].Categories, BagCategoryCurrentIndex, BagCategorySelectedIndex, function(currentIndex, selectedIndex)
 						BagCategoryCurrentIndex = currentIndex
 						if currentIndex ~= selectedIndex then
 							BagItemCurrentIndex = 1
@@ -1220,7 +1205,7 @@ if ActivateClothMarkers then
 						BagCategory = ListWarMenuCloth[1][5].CategoryIndex[BagCategorySelectedIndex]
 					end) then
 
-				elseif WarMenu.ComboBox('Extra 5 Item', ListWarMenuCloth[1][5].Items[BagCategorySelectedIndex], BagItemCurrentIndex, BagItemSelectedIndex, function(currentIndex, selectedIndex)
+				elseif WarMenu.ComboBox('Extra 4 Item', ListWarMenuCloth[1][5].Items[BagCategorySelectedIndex], BagItemCurrentIndex, BagItemSelectedIndex, function(currentIndex, selectedIndex)
 						BagItemCurrentIndex = currentIndex
 						if currentIndex ~= selectedIndex then
 							BagOptionCurrentIndex = 1
@@ -1236,7 +1221,7 @@ if ActivateClothMarkers then
 						BagOptionNameList = BagOptionNameListNew
 					end) then
 
-				elseif WarMenu.ComboBox('Extra 5 Option', BagOptionNameList, BagOptionCurrentIndex, BagOptionSelectedIndex, function(currentIndex, selectedIndex)
+				elseif WarMenu.ComboBox('Extra 4 Option', BagOptionNameList, BagOptionCurrentIndex, BagOptionSelectedIndex, function(currentIndex, selectedIndex)
 						BagOptionCurrentIndex = currentIndex
 						selectedIndex = currentIndex
 						BagOptionSelectedIndex = selectedIndex
@@ -1293,8 +1278,44 @@ if ActivateClothMarkers then
 				elseif WarMenu.MenuButton('Back to accessoires', 'WardrobeAccessoires') then
 				end
 				WarMenu.Display()
+			elseif WarMenu.IsMenuOpened('WardrobeSavedOutfits') then
+				if WarMenu.Button('Save Current Outfit') then
+					TriggerEvent('pd5m:db:SaveCurrentOutfit', Department, PedGender)
+				elseif WarMenu.MenuButton('Load Outfit', 'WardrobeLoadOutfit') then
+					LoadOutfitCurrentIndex = 1
+					LoadOutfitSelectedIndex = 1
+				elseif WarMenu.MenuButton('Delete Outfit', 'WardrobeDeleteOutfit') then
+					DeleteOutfitCurrentIndex = 1
+					DeleteOutfitSelectedIndex = 1
+				elseif WarMenu.MenuButton('Back to main menu', 'WardrobeMain') then
+				end
+				WarMenu.Display()
+			elseif WarMenu.IsMenuOpened('WardrobeLoadOutfit') then
+				if WarMenu.ComboBox("Outfit", DBWardrobeMenuData.ListOfOutfitNames[PedGender][Department], LoadOutfitCurrentIndex, LoadOutfitSelectedIndex, function(currentIndex, selectedIndex)
+					LoadOutfitCurrentIndex = currentIndex
+					selectedIndex = currentIndex
+					LoadOutfitSelectedIndex = selectedIndex
+					end) then
+						TriggerEvent('pd5m:db:LoadOutfit', DBWardrobeMenuData.ListOfOutfitNames[PedGender][Department][LoadOutfitSelectedIndex])
+				elseif WarMenu.MenuButton('Back to Saved Outfits', 'WardrobeSavedOutfits') then
+				end
+				WarMenu.Display()
+			elseif WarMenu.IsMenuOpened('WardrobeDeleteOutfit') then
+				if WarMenu.ComboBox("Outfit", DBWardrobeMenuData.ListOfOutfitNames[PedGender][Department], DeleteOutfitCurrentIndex, DeleteOutfitSelectedIndex, function(currentIndex, selectedIndex)
+					DeleteOutfitCurrentIndex = currentIndex
+					selectedIndex = currentIndex
+					DeleteOutfitSelectedIndex = selectedIndex
+					end) then
+						TriggerEvent('pd5m:db:DeleteOutfit', DBWardrobeMenuData.ListOfOutfitNames[PedGender][Department][DeleteOutfitSelectedIndex])
+						WarMenu.OpenMenu('WardrobeSavedOutfits')
+				elseif WarMenu.MenuButton('Back to Saved Outfits', 'WardrobeSavedOutfits') then
+				end
+				WarMenu.Display()
 			elseif IsControlJustPressed(0, 51) and atcloth and PlayerData.job.name == 'police' then
 				playerped = GetPlayerPed(-1)
+				Department = clothpolice
+				RankCurrentIndex = PlayerRanks[policeindex]
+				RankSelectedIndex = PlayerRanks[policeindex]
 				if GetEntityModel(playerped) == GetHashKey('mp_m_freemode_01') then
 					PedGender = 1
 					VariantList = ListMaleGloveVariants
@@ -1351,6 +1372,7 @@ if ActivateHealMarkers then
 		while true do
 			if IsControlJustPressed(0, 51) and atheal == true then -- e
 				SetEntityHealth(GetPlayerPed(-1), GetEntityMaxHealth(GetPlayerPed(-1)))
+				ClearPedBloodDamage(GetPlayerPed(-1))
 			end
 		Wait(0)
 		end
@@ -1697,6 +1719,12 @@ if ActivateWeaponMarkers then
 						ListWarMenuArmory = ListSAPRArmory
 					elseif weaponpolice == 'swat' then
 						ListWarMenuArmory = ListSWATArmory
+					elseif weaponpolice == 'lsfd' then
+						ListWarMenuArmory = ListFIREArmory
+					elseif weaponpolice == 'bcfd' then
+						ListWarMenuArmory = ListFIREArmory
+					elseif weaponpolice == 'dpos' then
+						ListWarMenuArmory = ListDPOSArmory
 					end
 
 					atweapon = true
@@ -1760,6 +1788,8 @@ if ActivateWeaponMarkers then
 					VestSelectedIndex = 1
 					VestDesignCurrentIndex = 1
 					VestDesignSelectedIndex = 1
+				elseif WarMenu.Button('Return all Weapons') then
+					RemoveAllPedWeapons(GetPlayerPed(-1), true)
 				elseif WarMenu.Button('Exit Menu') then
 					WarMenu.CloseMenu()
 				end
@@ -1978,6 +2008,136 @@ if ActivateEvidenceMarkers then
 				AddTextComponentSubstringPlayerName("You brought ~y~" .. NoItems .. "~s~ confiscated items to the evidence chamber.")
 				EndTextCommandThefeedPostMessagetext("CHAR_CALL911", "CHAR_CALL911", false, 4, "Evidence report", "")
 				EndTextCommandThefeedPostTicker(false, false)
+			end
+		Wait(0)
+		end
+	end)
+end
+
+-- -- Repair
+if ActivateRepairMarkers then
+	atrepair = false
+
+	CreateThread(function()
+		while true do
+			for i,coord in ipairs(list_repair_coords) do
+				local player_x, player_y, player_z = table.unpack(GetEntityCoords(PlayerPedId(), false))
+				local distance = Vdist2(coord.x, coord.y, coord.z, player_x, player_y, player_z)
+				if distance < 10 then
+					atrepair = true
+					StartHelpNotify('Press ~INPUT_CONTEXT~ to repair and clean your vehicle.', 500)
+					Wait(40)
+					while distance < 10 do
+						HelpNotify('Press ~INPUT_CONTEXT~ to repair and clean your vehicle.', 500)
+						Wait(500)
+						local player_x, player_y, player_z = table.unpack(GetEntityCoords(PlayerPedId(), false))
+						distance = Vdist2(coord.x, coord.y, coord.z, player_x, player_y, player_z)
+					end
+					EndHelpNotify('Press ~INPUT_CONTEXT~ to repair and clean your vehicle.', 500)
+					atrepair = false
+				end
+			end
+		Wait(1000)
+		end
+	end)
+
+	CreateThread(function()
+		while true do
+			if IsControlJustPressed(0, 51) and atrepair == true then -- e
+				if IsPedInAnyVehicle(GetPlayerPed(-1), false) then
+					local veh = GetVehiclePedIsIn(GetPlayerPed(-1), false)
+					SetVehicleEngineHealth(veh, 1000)
+					SetVehicleEngineOn(veh, true, true)
+					SetVehicleFixed(veh)
+					SetVehicleDirtLevel(veh, 0)
+				end
+			end
+			Wait(0)
+		end
+	end)
+end
+
+-- -- Impound
+if ActivateDeleteMarkers then
+	atdelete = false
+
+	CreateThread(function()
+		while true do
+			for i,coord in ipairs(list_delete_coords) do
+				local player_x, player_y, player_z = table.unpack(GetEntityCoords(PlayerPedId(), false))
+				local distance = Vdist2(coord.x, coord.y, coord.z, player_x, player_y, player_z)
+				if distance < 10 then
+					atdelete = true
+					StartHelpNotify('Look at a vehicle and press ~INPUT_CONTEXT~ to impound / delete it.', 500)
+					Wait(40)
+					while distance < 10 do
+						HelpNotify('Look at a vehicle and press ~INPUT_CONTEXT~ to impound / delete it.', 500)
+						Wait(500)
+						local player_x, player_y, player_z = table.unpack(GetEntityCoords(PlayerPedId(), false))
+						distance = Vdist2(coord.x, coord.y, coord.z, player_x, player_y, player_z)
+					end
+					EndHelpNotify('Look at a vehicle and press ~INPUT_CONTEXT~ to impound / delete it.', 500)
+					atdelete = false
+				end
+			end
+		Wait(1000)
+		end
+	end)
+
+	CreateThread(function()
+		while true do
+			if IsControlJustPressed(0, 51) and atdelete == true then -- e
+				local playerped = GetPlayerPed(-1)
+				if not IsPedInAnyVehicle(playerped, false) then
+					local camcoords = GetGameplayCamCoord()
+					local lookingvector = GetPlayerLookingVector(playerped, 10)
+					local flag_hasTarget, targetcoords, targetVeh = GetVehInDirection(camcoords, lookingvector)
+					if flag_hasTarget and GetEntityType(targetVeh) == 2 then
+						if GetVehicleNumberOfPassengers(targetVeh) == 0 and IsVehicleSeatFree(targetVeh, -1) then
+							SetEntityAsMissionEntity(targetVeh, true, true)
+							DeleteVehicle(targetVeh)
+						end
+					end
+				else
+					Notify('Exit the vehicle to impound it.')
+				end
+			end
+		Wait(0)
+		end
+	end)
+end
+
+-- -- TP Markers
+if ActivateTPMarkers then
+	attpmarker = false
+
+	CreateThread(function()
+		while true do
+			for i,coord in ipairs(list_tpmarker_coords) do
+				local player_x, player_y, player_z = table.unpack(GetEntityCoords(PlayerPedId(), false))
+				local distance = Vdist2(coord.x, coord.y, coord.z, player_x, player_y, player_z)
+				if distance < 5 then
+					attpmarker = true
+					StartHelpNotify('Press ~INPUT_CONTEXT~ to travel to another station.', 500)
+					Wait(40)
+					while distance < 5 do
+						HelpNotify('Press ~INPUT_CONTEXT~ to travel to another station.', 500)
+						Wait(500)
+						local player_x, player_y, player_z = table.unpack(GetEntityCoords(PlayerPedId(), false))
+						distance = Vdist2(coord.x, coord.y, coord.z, player_x, player_y, player_z)
+					end
+					EndHelpNotify('Press ~INPUT_CONTEXT~ to travel to another station.', 500)
+					attpmarker = false
+				end
+			end
+		Wait(1000)
+		end
+	end)
+
+	CreateThread(function()
+		while true do
+			if IsControlJustPressed(0, 51) and attpmarker == true then -- e
+				TriggerEvent('pd5m:hud:opentpmenu')
 			end
 		Wait(0)
 		end

--- a/HUD/tp_cl.lua
+++ b/HUD/tp_cl.lua
@@ -39,7 +39,7 @@ CreateThread(function()
 					SetEntityCoords(GetPlayerPed(-1), list_lspd_coords[LSPDCurrent].x, list_lspd_coords[LSPDCurrent].y, list_lspd_coords[LSPDCurrent].z, 1, 0, 0, 1)
 					TPMenuOpen = false
 					WarMenu.CloseMenu()
-			elseif WarMenu.ComboBox('BCSO Stations', BCSOStations, BCSOCurrent, BCSOSelected, function(currentIndex, selectedIndex)
+			elseif WarMenu.ComboBox('LSSD Stations', BCSOStations, BCSOCurrent, BCSOSelected, function(currentIndex, selectedIndex)
 					BCSOCurrent = currentIndex
 					BCSOSelected = selectedIndex
 				end) then

--- a/Service/tow_cl.lua
+++ b/Service/tow_cl.lua
@@ -429,10 +429,6 @@ AddEventHandler('pd5m:tow:aborttowtruck', function(TargetVehNetID)
 end)
 
 -- player used handler to get the variables the flatbedpickup-handler needs.
-RegisterNetEvent('pd5m:tow:playerflatbedpickup')
-AddEventHandler('pd5m:tow:playerflatbedpickup', function()
-
-end)
 
 -- handler to have flatbed pick up cars that are beside it.
 RegisterNetEvent('pd5m:tow:flatbedpickup')

--- a/Startup/startup_cl.lua
+++ b/Startup/startup_cl.lua
@@ -40,5 +40,4 @@ end)
 
 TriggerServerEvent('pd5m:msssv:InitMssTables')
 
-ClothingCurrentDrawables = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}
-ClothingCurrentTextures = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}
+TriggerServerEvent('pd5m:dbsv:PlayerConnected')

--- a/Startup/startup_sv.lua
+++ b/Startup/startup_sv.lua
@@ -1,0 +1,1 @@
+TriggerEvent('pd5m:dbsv:CheckMainDatabaseExists')

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -19,14 +19,16 @@ ConvarEnableEUP = true -- https://forum.cfx.re/t/release-eup-serve-and-rescue-la
                         -- you only need to install "eup-stream"
 
 -- Police station config variables
-ConvarEnableMissionRowSLB = false -- https://de.gta5-mods.com/maps/community-mission-row-pd
-ConvarEnablePaletoBayMatus = false -- https://de.gta5-mods.com/maps/paleto-bay-sheriff-s-office-extended-sp-and-fivem-mlo
-ConvarEnableSandyShoresBamboozled = false -- https://de.gta5-mods.com/maps/sandy-sheriff-office-extension-mlo-interior
-ConvarEnableBeaverBushSmokey = false -- https://forum.cfx.re/t/release-mlo-beaver-bush-park-ranger-station/1052889
+ConvarEnableMissionRowSLB = true -- https://de.gta5-mods.com/maps/community-mission-row-pd
+ConvarEnablePaletoBayMatus = true -- https://de.gta5-mods.com/maps/paleto-bay-sheriff-s-office-extended-sp-and-fivem-mlo
+ConvarEnableSandyShoresBamboozled = true -- https://de.gta5-mods.com/maps/sandy-sheriff-office-extension-mlo-interior
+ConvarEnableBeaverBushSmokey = true -- https://forum.cfx.re/t/release-mlo-beaver-bush-park-ranger-station/1052889
+ConvarEnableLaMesaMatus = true -- https://esx-scripts.com/de/shop/san-andreas-highway-patrol-mlo/
+ConvarEnableDelPerroPablito = true -- https://de.gta5-mods.com/maps/del-perro-police-department-mlo-add-on-fivem
 
 -- Fire station and hospital config variables
-ConvarEnablePaletoBayBrown = false -- https://de.gta5-mods.com/maps/mlo-paleto-bay-medical-center
-ConvarEnableSandyShoresBeek = false -- https://de.gta5-mods.com/maps/sandy-shores-hospital-mlo-interior-add-on-fivem
+ConvarEnablePaletoBayBrown = true -- https://de.gta5-mods.com/maps/mlo-paleto-bay-medical-center
+ConvarEnableSandyShoresBeek = true -- https://de.gta5-mods.com/maps/sandy-shores-hospital-mlo-interior-add-on-fivem
 
 -- Vehicle config variables
 ConvarEnableELSLSPDt0yPack = false -- https://www.lcpdfr.com/downloads/gta5mods/vehiclemodels/17911-los-santos-police-department-mega-pack-els/
@@ -35,6 +37,7 @@ ConvarEnableELSSAHPTheHurkPack = false -- https://forum.cfx.re/t/release-2017-ca
 
 
 -- Main system config variables
+ConvarEnableDatabase = true -- Enables the json database script of pd5m. Currently saves player outfits.
 ConvarEnableMainScript = true -- Enables Interaction with peds, radialmenu and many other scripts. If deactivated markers still function properly.
 ConvarEnableMissionScript = true -- Enables Ambient Events; only works with main script enabled
 
@@ -75,10 +78,9 @@ client_scripts {
 -- Loading station config files
 client_scripts {
   "Config/Stations/Police/DavisVanilla.lua",
-  "Config/Stations/Police/DelPerroVanilla.lua",
-  "Config/Stations/Police/LaMesaVanilla.lua",
   "Config/Stations/Police/RockfordVanilla.lua",
   "Config/Stations/Police/VespucciVanilla.lua",
+  "Config/Stations/Police/VespucciBeachVanilla.lua",
   "Config/Stations/Police/VinewoodVanilla.lua",
   "Config/Stations/Med/CentralLSVanilla.lua",
   "Config/Stations/Med/DavisFDVanilla.lua",
@@ -165,6 +167,26 @@ else
   }
 end
 
+if ConvarEnableLaMesaMatus == true then
+  client_scripts {
+    "Config/Stations/Police/LaMesaMatus.lua",
+  }
+else
+  client_scripts {
+    "Config/Stations/Police/LaMesaVanilla.lua",
+  }
+end
+
+if ConvarEnableDelPerroPablito == true then
+  client_scripts {
+    "Config/Stations/Police/DelPerroPablito.lua",
+  }
+else
+  client_scripts {
+    "Config/Stations/Police/DelPerroVanilla.lua",
+  }
+end
+
 -- Loading Garage config files
 client_scripts {
   "Config/Garages/Files/saprgaragesvanilla.lua",
@@ -213,6 +235,8 @@ if ConvarEnableEUP then
     "Config/Armories/Files/SASPArmoryEUP.lua",
     "Config/Armories/Files/SAPRArmoryEUP.lua",
     "Config/Armories/Files/SWATArmoryEUP.lua",
+    "Config/Armories/Files/DPOSArmoryEUP.lua",
+    "Config/Armories/Files/FireArmoryEUP.lua",
   }
 else
   client_scripts {
@@ -222,6 +246,8 @@ else
     "Config/Armories/Files/SASPArmoryVanilla.lua",
     "Config/Armories/Files/SAPRArmoryVanilla.lua",
     "Config/Armories/Files/SWATArmoryVanilla.lua",
+    "Config/Armories/Files/FireArmoryVanilla.lua",
+    "Config/Armories/Files/DPOSArmoryVanilla.lua",
   }
 end
 
@@ -310,6 +336,25 @@ client_scripts {
 	"Config/Wardrobes/wardrobe_cl.lua",
 	"Config/Wardrobes/CategoryDefinitions_cl.lua",
 }
+
+-- Loading database
+if ConvarEnableDatabase then
+  server_scripts {
+    "Database/database_sv.lua",
+    "Database/jsonhandler_sv.lua",
+  }
+
+  client_scripts {
+    "Database/database_cl.lua",
+  }
+else
+  server_scripts {
+    "Database/NoDB_sv.lua"
+  }
+  client_scripts {
+    "Database/NoDB_cl.lua"
+  }
+end
 
 -- Loading marker system
 server_scripts {


### PR DESCRIPTION
This release updates the wardrobe to EUP-Version 9.3 and includes the 
option to save your outfits. It also includes Armories for Tow Trucks 
and Fire Departments with Fire Extinguishers and Jerry Cans.

- Armories and Wardrobe have been updated to EUP 9.3
- Json-Database to save outfits for each department
- BCSO has changed to LSSD
- Added Support for SAHP-Station LaMesa by Matus and LSPD-Station Del 
Perro Pier by Pablito
- Added TP-markers at every department, removed /tp-command
- Added the rank-command into the wardrobe, removed /rank-command
- Added Vehicle-Repair and -Impound/Deletion Markers. They are located 
at every tow truck station and a few police stations
- Ped Props now get removed when you open the uniform tab in the 
wardrobe